### PR TITLE
fix: publication to PyPiTest

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -23,7 +25,6 @@ jobs:
       - name: Install dependencies
         run: |
             python -m pip install uv
-            python -m uv pip install .
             python -m uv pip install build
 
       - name: Build the CLI

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,3 +13,10 @@ ignore_missing_imports = True
 
 [mypy-grpc]
 ignore_missing_imports = True
+
+
+[mypy-setuptools]
+ignore_missing_imports = True
+
+[mypy-setuptools_scm]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=64",
-            "setuptools-scm>=8",
+            "setuptools-scm[toml]>=8",
             "wheel"]
 build-backend = "setuptools.build_meta"
 
@@ -58,8 +58,3 @@ dev = [
 
 [project.scripts]
 armonik = "armonik_cli.cli:cli"
-
-[tool.setuptools_scm]
-version_scheme = "post-release"
-local_scheme = "no-local-version"
-version_file = "src/armonik_cli/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,40 @@
+# WARNING: This setup.py script is only for customizing the local version scheme with setuptools-scm.
+# All other project configuration must be provided in pyproject.toml. Use this script cautiously and
+# refer to the documentation for more details: https://setuptools-scm.readthedocs.io/en/latest/customizing/.
+# For more details on the use of setup.py and its deprecated features, please refer to:
+# https://packaging.python.org/en/latest/discussions/setup-py-deprecated/
+
+from os import environ
+from setuptools import setup
+from setuptools_scm import ScmVersion
+
+
+def get_local_schema(version: ScmVersion) -> str:
+    """
+    Generate a custom local version scheme for setuptools-scm.
+
+    Generates a local version string based on environment variables. If RELEASE is unset,
+    appends .dev<run_id> for development builds; otherwise, returns an empty string. The
+    value of <run_id> is retrieved from the GITHUB_RUN_ID environment variable if it exists,
+    otherwise the default value used is 0.
+
+    Args:
+        version: The ScmVersion object passed by setuptools-scm.
+
+    Returns:
+        The custom local version string.
+    """
+    run_id = environ.get("GITHUB_RUN_ID", "0")
+    release = environ.get("RELEASE", "")
+    if not release:
+        return f".dev{run_id}"
+    return ""
+
+
+setup(
+    use_scm_version={
+        "version_scheme": "post-release",
+        "local_scheme": get_local_schema,
+        "version_file": "src/armonik_cli/_version.py",
+    }
+)


### PR DESCRIPTION
# Motivation

The project workflow dedicated to publishing test versions on test.pypi.org fails when a pull request is updated without adding new commits to the previous ones.

# Description

This change fixes this issue by generating a unique version each time the pipeline is run. This solution is a work around that uses setup.py. This is not ideal and a better solution should be implemented when possible. For more details on the reasons for this change, see:
* this stack overflow [thread](https://stackoverflow.com/questions/73605607/how-to-use-setuptools-scm) on the limitations of setuptools_scm.
* this [page](https://setuptools-scm.readthedocs.io/en/latest/customizing/) in the setuptools-scm documentation describing how to customize a version.

# Testing

Tested using the CI.

# Impact

Project test versions are available on test.pypi.org for each run of the publish workflow.

# Additional Information

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
