### PR TITLE
feat: add short help option

### DIFF
--- a/src/armonik_cli/cli.py
+++ b/src/armonik_cli/cli.py
@@ -3,7 +3,7 @@ import rich_click as click
 from armonik_cli import commands, __version__
 
 
-@click.group(name="armonik")
+@click.group(name="armonik", context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=__version__, prog_name="armonik")
 def cli() -> None:
     """

--- a/tests/commands/test_sessions.py
+++ b/tests/commands/test_sessions.py
@@ -61,6 +61,11 @@ serialized_session = {
 }
 
 
+@pytest.mark.parametrize("flag", ["", "-h", "--help"])
+def test_session(flag):
+    run_cmd_and_assert_exit_code(f"session {flag}")
+
+
 @pytest.mark.parametrize(
     "cmd",
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import pytest
+
 from conftest import run_cmd_and_assert_exit_code
 
 
@@ -6,5 +8,6 @@ def test_armonik_version():
     assert result.output.startswith("armonik, version ")
 
 
-def test_armonik_help():
-    run_cmd_and_assert_exit_code("--help")
+@pytest.mark.parametrize("flag", ["--help", "-h"])
+def test_armonik_help(flag):
+    run_cmd_and_assert_exit_code(flag)


### PR DESCRIPTION
# Motivation

Add the short flag "-h" to display help message on all commands.

# Description

Update CLI configuration to add the short help flag.

# Testing

Unit tests updated.

# Impact

No impact, this modification maintains backward compatibility.

# Additional Information

No.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
