### PR TITLE
feat: add filter support in command-line arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "armonik",
     "click",
+    "lark",
     "PyYAML",
     "rich_click",
 ]

--- a/src/armonik_cli/commands/sessions.py
+++ b/src/armonik_cli/commands/sessions.py
@@ -6,8 +6,9 @@ from typing import List, Tuple, Union
 
 from armonik.client.sessions import ArmoniKSessions
 from armonik.common import SessionStatus, Session, TaskOptions
+from armonik.common.filter import SessionFilter
 
-from armonik_cli.core import console, base_command, KeyValuePairParam, TimeDeltaParam
+from armonik_cli.core import console, base_command, KeyValuePairParam, TimeDeltaParam, FilterParam
 
 
 SESSION_TABLE_COLS = [("ID", "SessionId"), ("Status", "Status"), ("CreatedAt", "CreatedAt")]
@@ -21,12 +22,20 @@ def sessions() -> None:
 
 
 @sessions.command()
+@click.option(
+    "-f",
+    "--filter",
+    type=FilterParam("Session"),
+    required=False,
+    help="An expression to filter the sessions to be listed.",
+    metavar="FILTER EXPR",
+)
 @base_command
-def list(endpoint: str, output: str, debug: bool) -> None:
+def list(endpoint: str, output: str, filter: Union[SessionFilter, None], debug: bool) -> None:
     """List the sessions of an ArmoniK cluster."""
     with grpc.insecure_channel(endpoint) as channel:
         sessions_client = ArmoniKSessions(channel)
-        total, sessions = sessions_client.list_sessions()
+        total, sessions = sessions_client.list_sessions(session_filter=filter)
 
     if total > 0:
         sessions = [_clean_up_status(s) for s in sessions]

--- a/src/armonik_cli/core/__init__.py
+++ b/src/armonik_cli/core/__init__.py
@@ -1,6 +1,6 @@
 from armonik_cli.core.console import console
 from armonik_cli.core.decorators import base_command
-from armonik_cli.core.params import KeyValuePairParam, TimeDeltaParam
+from armonik_cli.core.params import KeyValuePairParam, TimeDeltaParam, FilterParam
 
 
-__all__ = ["base_command", "KeyValuePairParam", "TimeDeltaParam", "console"]
+__all__ = ["base_command", "KeyValuePairParam", "TimeDeltaParam", "FilterParam", "console"]

--- a/src/armonik_cli/core/filter_grammar.lark
+++ b/src/armonik_cli/core/filter_grammar.lark
@@ -1,0 +1,47 @@
+?start: expr
+
+expr: term (OR term)*
+
+term: factor (AND factor)*
+
+factor: NOT? atom
+
+?atom: "(" expr ")"
+    | identifier operator value -> comparison
+    | identifier -> test
+
+identifier: LITERAL | "options" LBRACKET value RBRACKET
+?operator: EQ  | NEQ | LT | LTE | GT | GTE | CONTAINS | NOTCONTAINS
+                | STARTSWITH | ENDSWIDTH | IS
+?value: LITERAL | STRING | DATETIME | DURATION | SIGNED_NUMBER
+
+// Boolean operators
+OR: "or" | "OR" | "|" | "||"
+AND: "and" | "AND" | "&" | "&&"
+NOT: "not" | "NOT" | "!" | "~"
+
+// Comparison operators
+EQ: "=" | "=="
+NEQ: "!="
+LT: "<"
+LTE: "<="
+GT: ">"
+GTE: ">="
+CONTAINS: "contains" | "~"
+NOTCONTAINS: "notcontains" | "!~"
+STARTSWITH: "startswith"
+ENDSWIDTH: "endswith"
+IS: "is" | "IS"
+
+// Terminals types
+LITERAL: /[a-zA-Z_][a-zA-Z0-9-_\.]*/
+STRING: /(".*?(?<!\\)(\\\\)*?"|'.*?(?<!\\)(\\\\)*?')/i
+DATETIME: /\d{4}-\d{2}-\d{2}(?:T\d{1,2}:\d{2}:\d{2}(?:\.\d+)?)?/
+DURATION: /-?(?:\d+\.)?\d{1,2}:\d{2}:\d{2}(?:\.\d+)?/
+LBRACKET: "["
+RBRACKET: "]"
+
+%import common.SIGNED_NUMBER
+%import common.WS
+
+%ignore WS

--- a/src/armonik_cli/core/filters.py
+++ b/src/armonik_cli/core/filters.py
@@ -1,0 +1,580 @@
+import operator
+from datetime import datetime
+from functools import reduce
+from pathlib import Path
+from typing import cast, Any, List, Callable, Union, Optional
+
+from armonik.common import (
+    Filter,
+    Partition,
+    Result,
+    ResultStatus,
+    Session,
+    SessionStatus,
+    Task,
+    TaskStatus,
+)
+from armonik.common.filter import (
+    BooleanFilter,
+    PartitionFilter,
+    ResultFilter,
+    SessionFilter,
+    StringFilter,
+    TaskFilter,
+    TaskOptionFilter,
+    StatusFilter,
+    FilterError,
+)
+from armonik.common.filter.filter import FType
+from lark import Lark, Transformer, Token
+
+from armonik_cli.utils import parse_time_delta, remove_string_delimiters
+
+
+class SemanticError(Exception):
+    """
+    Exception raised for semantic errors in filter expressions.
+
+    Attributes:
+        msg: The error message describing the semantic issue.
+        expr: The filter expression where the error occurred.
+        pos: The position of the error in the expression (zero-based index).
+        context: A snippet of the expression showing the error in context.
+    """
+
+    def __init__(self, msg: str, expr: str, column: Optional[int] = None) -> None:
+        super().__init__()
+        self.msg = msg
+        self.expr = expr
+        self.pos = column - 1 if column is not None else -1
+        self.context = self.get_context(80)
+
+    def get_context(self, span: int) -> str:
+        """
+        Generate a context string highlighting the error position in the expression.
+
+        Args:
+            span: The number of characters to show before and after the error.
+
+        Returns:
+            A formatted string showing the error context.
+        """
+        start = max(self.pos - span, 0)
+        end = self.pos + span
+        before = self.expr[start : self.pos].rsplit("\n", 1)[-1]
+        after = self.expr[self.pos : end].split("\n", 1)[0]
+        return f"\n\t{before}{after}\n\t" + len(before.expandtabs()) * " " + "^\n\n"
+
+    def __str__(self) -> str:
+        """
+        Generate a string representation of the semantic error.
+
+        Returns:
+            A detailed error message.
+        """
+        message = "Invalid filter expression.\n"
+        message += self.context
+        message += self.msg
+        return message
+
+
+class FilterParser:
+    """
+    A parser for processing and validating filter expressions.
+
+    Attributes:
+        obj: The ArmoniK API object associated with the filter.
+        filter: The ArmoniK API filter corresponding to the object.
+        status_enum: The enumeration for the object's status, if applicable.
+        options_fields: Whether to allow filtering by options fields (e.g., TaskOptions).
+        output_fields: Whether to allow filtering by output fields for Task filters.
+    """
+
+    _grammar_file = Path(__file__).parent / "filter_grammar.lark"
+
+    def __init__(
+        self,
+        obj: Union[Partition, Result, Session, Task],
+        filter: Union[PartitionFilter, ResultFilter, SessionFilter, TaskFilter],
+        status_enum: Optional[Union[ResultStatus, SessionStatus, TaskStatus, None]] = None,
+        options_fields: bool = False,
+        output_fields: bool = False,
+    ) -> None:
+        self.obj = obj
+        self.filter = filter
+        self.status_enum = status_enum
+        self.options_fields = options_fields
+        self.output_fields = output_fields
+
+    @classmethod
+    def get_parser(cls) -> Lark:
+        """
+        Generate a Lark parser for the grammar associated with the filter.
+
+        Returns:
+            A Lark parser instance.
+        """
+        with cls._grammar_file.open() as file:
+            grammar = file.read()
+            return Lark(grammar, start="start", parser="earley")
+
+    def parse(self, expression: str) -> Filter:
+        """
+        Parse a filter expression into a Filter object.
+
+        Args:
+            expression: The filter expression as a string.
+
+        Returns:
+            A Filter object constructed from the parsed expression.
+        """
+        tree = self.get_parser().parse(expression)
+        filter = FilterTransformer(
+            obj=self.obj,
+            filter=self.filter,
+            status_enum=self.status_enum,
+            options_fields=self.options_fields,
+            output_fields=self.output_fields,
+            expr=expression,
+        ).transform(tree)
+        return filter
+
+
+class FilterTransformer(Transformer):
+    """
+    A transformer to convert parsed filter expressions into Filter objects.
+
+    Attributes:
+        obj: The ArmoniK API object associated with the filter.
+        filter: The ArmoniK API filter corresponding to the object.
+        status_enum: The object status enumeration.
+        options_fields: Whether options fields are allowed in the filter.
+        output_fields: Whether output fields are allowed in the filter.
+        expr: The original filter expression.
+    """
+
+    def __init__(
+        self,
+        obj: Union[Partition, Result, Session, Task],
+        filter: Union[PartitionFilter, ResultFilter, SessionFilter, TaskFilter],
+        expr: str,
+        status_enum: Optional[Union[ResultStatus, SessionStatus, TaskStatus, None]] = None,
+        options_fields: bool = False,
+        output_fields: bool = False,
+    ) -> None:
+        super().__init__(visit_tokens=True)
+        self._obj = obj
+        self._filter = filter
+        self._status_enum = status_enum
+        self._expr = expr
+        self._options_fields = options_fields
+        self._output_fields = output_fields
+
+    def expr(self, args: List[Union[Filter, Token]]) -> Filter:
+        """
+        Combine multiple filter expressions using logical OR.
+
+        Args:
+            args: A list of filters and OR tokens.
+
+        Returns:
+            The combined filter expression.
+        """
+        return reduce(operator.or_, [item for item in args if not isinstance(item, Token)])
+
+    def term(self, args: List[Union[Filter, Token]]) -> Filter:
+        """
+        Combine multiple filter expressions using logical AND.
+
+        Args:
+            args: A list of filters and AND tokens.
+
+        Returns:
+            The combined filter expression.
+        """
+        return reduce(operator.and_, [item for item in args if not isinstance(item, Token)])
+
+    def factor(self, args: List[Union[Filter, Token]]) -> Filter:
+        """
+        Process a single filter or its negation.
+
+        Args:
+            args: A list containing a single filter and an optional token for its negation.
+
+        Returns:
+            The processed filter.
+        """
+        if len(args) == 1:
+            return args[0]
+        elif len(args) == 2:
+            return -cast(Filter, args[1])
+        msg = f"Unexpected token sequence: {args}."
+        raise ValueError(msg)
+
+    def comparison(self, args: List[Token]) -> Filter:
+        """
+        Process a comparison expression.
+
+        Args:
+            args: Tokens representing the comparison (field, operator, value).
+
+        Returns:
+            The resulting filter.
+        """
+        if len(args) != 3:
+            msg = f"Unexpected token sequence: {args}."
+            raise ValueError(msg)
+        _, filter = args[0].value
+        op: Callable[[Filter, Any], Filter] = args[1].value
+        value: str = args[2].value
+
+        try:
+            if isinstance(filter, StatusFilter):
+                value = getattr(self._status_enum, value.upper())
+            return op(filter, value)
+        except FilterError as error:
+            if error.message.startswith("Operator"):
+                tok = args[1]
+            elif error.message.startswith("Expected value type"):
+                tok = args[2]
+            else:
+                tok = args[0]
+            raise SemanticError(
+                msg=error.message,
+                expr=self._expr,
+                column=tok.column,
+            )
+        except AttributeError:
+            msg = f"{self._obj.__name__.lower()} has no status '{value}'."
+            raise SemanticError(
+                msg=msg,
+                expr=self._expr,
+                column=args[2].column,
+            )
+        except AttributeError:
+            msg = f"{self._obj.__name__.lower()} has no status '{value}'."
+            raise SemanticError(
+                msg=msg,
+                expr=self._expr,
+                column=args[2].column,
+            )
+
+    def test(self, args: List[Token]) -> BooleanFilter:
+        """
+        Process a test expression.
+
+        Args:
+            args: A list of tokens containing the field and filter data.
+
+        Returns:
+            The boolean filter extracted from the token.
+
+        Raises:
+            SemanticError: If the field's filter is not a boolean field.
+            ValueError: If an unexpected token sequence is provided.
+        """
+        if len(args) == 1:
+            field, filter = args[0].value
+            if isinstance(filter, BooleanFilter):
+                return filter
+            msg = f"{self._obj.__name__.capitalize()} filter's '{field}' field is not a boolean field."
+            raise SemanticError(
+                msg=msg,
+                expr=self._expr,
+                column=args[0].column,
+            )
+        msg = f"Unexcepted token sequence: {args}."
+        raise ValueError(msg)
+
+    def identifier(self, args: List[Token]) -> Token:
+        """
+        Resolves and validates an identifier token, updating its value based on field type.
+
+        Args:
+            args: A list of tokens containing identifier details.
+
+        Returns:
+            The updated token with resolved field information.
+
+        Raises:
+            SemanticError: If the field is invalid or unsupported.
+            ValueError: If an unexpected token sequence is provided.
+        """
+        if len(args) == 1:
+            field = args[0].value
+            if field.startswith("options."):
+                option_field = field[8:]
+                if not self._options_fields:
+                    msg = f"{self._obj.__name__.capitalize()} fillers don't have options fields."
+                    raise SemanticError(
+                        msg=msg,
+                        expr=self._expr,
+                        column=args[0].column,
+                    )
+                if (
+                    option_field not in TaskOptionFilter._fields
+                    or TaskOptionFilter._fields[option_field][0] == FType.NA
+                    or TaskOptionFilter._fields[option_field][0] == FType.UNKNOWN
+                ):
+                    msg = f"{self._obj.__name__.capitalize()} fillers don't have a field '{option_field}' in the option fields."
+                    raise SemanticError(
+                        msg=msg,
+                        expr=self._expr,
+                        column=args[0].column,
+                    )
+                return args[0].update(value=(field, getattr(self._obj.options, option_field)))
+            elif field.startswith("output."):
+                output_field = field[7:]
+                if not self._output_fields:
+                    msg = f"{self._obj.__name__.capitalize()} fillers don't have output fields."
+                    raise SemanticError(
+                        msg=msg,
+                        expr=self._expr,
+                        column=args[0].column,
+                    )
+                if output_field != "error":
+                    msg = f"{self._obj.__name__.capitalize()} fillers don't have a field '{output_field}' in the output fields."
+                    raise SemanticError(
+                        msg=msg,
+                        expr=self._expr,
+                        column=args[0].column,
+                    )
+                return args[0].update(value=(field, getattr(self._obj.output, output_field)))
+            if (
+                field not in self._filter._fields
+                or self._filter._fields[field][0] == FType.NA
+                or self._filter._fields[field][0] == FType.UNKNOWN
+            ):
+                msg = f"{self._obj.__name__.capitalize()} filters don't have a field '{field}'."
+                raise SemanticError(
+                    msg=msg,
+                    expr=self._expr,
+                    column=args[0].column,
+                )
+            return args[0].update(value=(field, getattr(self._obj, field)))
+        elif len(args) == 3:
+            key = args[1].value
+            if not self._options_fields:
+                msg = f"{self._obj.__name__.capitalize()} fillers have no options fields and therefore no custom option fields.."
+                raise SemanticError(
+                    msg=msg,
+                    expr=self._expr,
+                    column=args[0].column,
+                )
+            return args[1].update(value=(f"option['{key}']", self._obj.options[key]))
+        msg = f"Unexcepted token sequence: {args}."
+        raise ValueError(msg)
+
+    def STRING(self, tok: Token) -> Token:
+        """
+        Processes a STRING token by removing delimiters.
+
+        Args:
+            tok: A STRING token.
+
+        Returns:
+            The updated token with delimiters removed.
+        """
+        return tok.update(value=remove_string_delimiters(tok.value))
+
+    def SIGNED_NUMBER(self, tok: Token) -> Token:
+        """
+        Converts a SIGNED_NUMBER token to an integer.
+
+        Args:
+            tok: A SIGNED_NUMBER token.
+
+        Returns:
+            The updated token with an integer value.
+        """
+        return tok.update(value=int(tok.value))
+
+    def DATETIME(self, tok: Token) -> Token:
+        """
+        Parses a DATETIME token into a Python datetime object.
+
+        Args:
+            tok: A DATETIME token.
+
+        Returns:
+            The updated token with a datetime value.
+        """
+        return tok.update(
+            value=datetime.strptime(
+                tok.value, "%Y-%m-%dT%H:%M:%S" if "T" in tok.value else "%Y-%m-%d"
+            )
+        )
+
+    def DURATION(self, tok: Token) -> Token:
+        """
+        Parses a DURATION token into a timedelta object.
+
+        Args:
+            tok: A DURATION token.
+
+        Returns:
+            The updated token with a timedelta value.
+        """
+        return tok.update(value=parse_time_delta(tok.value))
+
+    def EQ(self, tok: Token) -> Token:
+        """
+        Maps an EQ token to the equality operator.
+
+        Args:
+            tok: An EQ token.
+
+        Returns:
+            The updated token with the equality operator.
+        """
+        return tok.update(value=operator.eq)
+
+    def NEQ(self, tok: Token) -> Token:
+        """
+        Maps an EQ token to the unequality operator.
+
+        Args:
+            tok: An NEQ token.
+
+        Returns:
+            The updated token with the unequality operator.
+        """
+        return tok.update(value=operator.ne)
+
+    def LT(self, tok: Token) -> Token:
+        """
+        Maps an LT token to the lower than operator.
+
+        Args:
+            tok: An LT token.
+
+        Returns:
+            The updated token with the lower than operator.
+        """
+        return tok.update(value=operator.lt)
+
+    def LTE(self, tok: Token) -> Token:
+        """
+        Maps an LTE token to the lower than or equal operator.
+
+        Args:
+            tok: An LTE token.
+
+        Returns:
+            The updated token with the lower than or equal operator.
+        """
+        return tok.update(value=operator.le)
+
+    def GT(self, tok: Token) -> Token:
+        """
+        Maps an GT token to the greater than operator.
+
+        Args:
+            tok: An GT token.
+
+        Returns:
+            The updated token with the greater than operator.
+        """
+        return tok.update(value=operator.gt)
+
+    def GTE(self, tok: Token) -> Token:
+        """
+        Maps an GTE token to the greater than or equal operator.
+
+        Args:
+            tok: An GTE token.
+
+        Returns:
+            The updated token with the greater than or equal operator.
+        """
+        return tok.update(value=operator.ge)
+
+    def CONTAINS(self, tok: Token) -> Token:
+        """
+        Maps an CONTAINS token to a contains operator.
+
+        Args:
+            tok: An CONTAINS token.
+
+        Returns:
+            The updated token with a function mimicking the contains operator.
+        """
+
+        def contains_func(filter: StringFilter, substr: str) -> BooleanFilter:
+            return filter.contains(substr)
+
+        return tok.update(value=contains_func)
+
+    def NOTCONTAINS(self, tok: Token) -> Token:
+        """
+        Maps an NOTCONTAINS token to a not contains operator.
+
+        Args:
+            tok: An EQ token.
+
+        Returns:
+            The updated token with a function mimicking the not contains operator
+        """
+
+        def notcontains_func(filter: StringFilter, substr: str) -> BooleanFilter:
+            return -filter.contains(substr)
+
+        return tok.update(value=notcontains_func)
+
+    def STARTSWITH(self, tok: Token) -> Token:
+        """
+        Maps an STARTSWITH token to a starts with operator.
+
+        Args:
+            tok: An STARTSWITH token.
+
+        Returns:
+            The updated token with a function mimicking the starts with operator
+        """
+
+        def startswith_func(filter: StringFilter, prefix: str) -> BooleanFilter:
+            return filter.startswith(prefix)
+
+        return tok.update(value=startswith_func)
+
+    def ENDSWIDTH(self, tok: Token) -> Token:
+        """
+        Maps an ENDSWITH token to the ends with operator.
+
+        Args:
+            tok: An ENDSWITH token.
+
+        Returns:
+            The updated token with a function mimicking the ends with operator
+        """
+
+        def endswith_func(filter: StringFilter, suffix: str) -> BooleanFilter:
+            return filter.endswith(suffix)
+
+        return tok.update(value=endswith_func)
+
+    def IS(self, tok: Token) -> Token:
+        """
+        Processes an IS token to evaluate a boolean filter.
+
+        Args:
+            tok: An IS token.
+
+        Returns:
+            The updated token with a function for boolean evaluation.
+        """
+
+        def is_func(filter: BooleanFilter, bool_str: str) -> BooleanFilter:
+            if bool_str.lower() == "true":
+                return filter
+            elif bool_str.lower() == "false":
+                return -filter
+            else:
+                msg = f"Invalid value for boolean field: {bool_str}."
+                raise SemanticError(
+                    msg=msg,
+                    expr=self._expr,
+                    column=tok.column,
+                )
+
+        return tok.update(value=is_func)

--- a/src/armonik_cli/core/params.py
+++ b/src/armonik_cli/core/params.py
@@ -5,6 +5,12 @@ import rich_click as click
 from datetime import timedelta
 from typing import cast, Tuple, Union
 
+from armonik.common import Filter
+from lark.exceptions import VisitError, UnexpectedInput
+
+from armonik_cli.utils import parse_time_delta
+from armonik_cli.core.filters import FilterParser
+
 
 class KeyValuePairParam(click.ParamType):
     """
@@ -72,30 +78,60 @@ class TimeDeltaParam(click.ParamType):
             click.BadParameter: If the input does not match the expected time format.
         """
         try:
-            return self._parse_time_delta(value)
+            return parse_time_delta(value)
         except ValueError:
             self.fail(f"{value} is not a valid time delta. Use HH:MM:SS.MS.", param, ctx)
 
-    @staticmethod
-    def _parse_time_delta(time_str: str) -> timedelta:
+
+class FilterParam(click.ParamType):
+    """
+    A custom Click parameter type that parses a string expression into a valid ArmoniK API filter.
+
+    Attributes:
+        name: The name of the parameter type, used by Click.
+    """
+
+    name = "filter"
+
+    def __init__(self, filter_type: str) -> None:
+        super().__init__()
+        try:
+            filter_type = filter_type.capitalize()
+            from armonik import common
+
+            self.parser = FilterParser(
+                obj=getattr(common, filter_type),
+                filter=getattr(common.filter, f"{filter_type}Filter"),
+                status_enum=getattr(common, f"{filter_type}Status")
+                if filter_type != "Partition"
+                else None,
+                options_fields=(filter_type == "Task" or filter_type == "Session"),
+                output_fields=filter_type == "Task",
+            )
+        except AttributeError:
+            msg = f"'{filter_type}' is not a valid filter type."
+            raise ValueError(msg)
+
+    def convert(
+        self, value: str, param: Union[click.Parameter, None], ctx: Union[click.Context, None]
+    ) -> Filter:
         """
-        Parses a time string in the format "HH:MM:SS.MS" into a datetime.timedelta object.
+        Converts the input value into a valid ArmoniK API filter.
 
         Args:
-            time_str (str): A string representing a time duration in hours, minutes,
-                            seconds, and milliseconds (e.g., "12:34:56.789").
+            value: The input value to be converted.
+            param: The parameter object passed by Click.
+            ctx: The context in which the parameter is being used.
 
         Returns:
-            timedelta: A datetime.timedelta object representing the parsed time duration.
+            A filter object.
 
         Raises:
-            ValueError: If the input string is not in the correct format.
+            click.BadParameter: If the input contains a syntax error.
         """
-        hours, minutes, seconds = time_str.split(":")
-        sec, microseconds = (seconds.split(".") + ["0"])[:2]  # Handle missing milliseconds
-        return timedelta(
-            hours=int(hours),
-            minutes=int(minutes),
-            seconds=int(sec),
-            milliseconds=int(microseconds.ljust(3, "0")),  # Ensure 3 digits for milliseconds
-        )
+        try:
+            return self.parser.parse(value)
+        except UnexpectedInput as error:
+            self.fail(f"Filter syntax error: {error.get_context(value, span=40)}.", param, ctx)
+        except VisitError as error:
+            self.fail(str(error.orig_exc), param, ctx)

--- a/src/armonik_cli/utils.py
+++ b/src/armonik_cli/utils.py
@@ -1,0 +1,45 @@
+from datetime import timedelta
+
+
+def parse_time_delta(time_str: str) -> timedelta:
+    """
+    Parses a time string in the format "D.HH:MM:SS.FRAC" into a datetime.timedelta object.
+
+    Args:
+        time_str: A string representing a time duration in days, hours, minutes,
+                        seconds, and fractional seconds (e.g., "15.12:34:56.789183").
+
+    Returns:
+        A datetime.timedelta object representing the parsed time duration.
+
+    Raises:
+        ValueError: If the input string is not in the correct format.
+    """
+    negative = False
+    if time_str[0] == "-":
+        negative = True
+        time_str = time_str[0:]
+    hours, minutes, seconds = time_str.split(":")
+    days, hours = (["0"] + hours.split("."))[-2:]
+    sec, fractional_sec = (seconds.split(".") + ["0"])[:2]
+    return (-1 if negative else 1) * timedelta(
+        days=int(days),
+        hours=int(hours),
+        minutes=int(minutes),
+        seconds=int(sec),
+        microseconds=int(float(f"0.{fractional_sec}") * 10**6),
+    )
+
+
+def remove_string_delimiters(s: str) -> str:
+    """Remove delimiters ' or " from a string.
+
+    Args:
+        s: A string.
+
+    Returns:
+        The same string without delimiters if it has some.
+    """
+    if s[0] == s[-1] == '"' or s[0] == s[-1] == "'":
+        return s[1:-1]
+    return s

--- a/tests/core/test_filters.py
+++ b/tests/core/test_filters.py
@@ -1,0 +1,201 @@
+import pytest
+
+from datetime import datetime, timedelta
+
+from armonik.common import Partition, Result, ResultStatus, Session, SessionStatus, Task, TaskStatus
+from armonik.common.filter import PartitionFilter, ResultFilter, SessionFilter, TaskFilter
+
+from armonik_cli.core.filters import FilterParser
+
+
+@pytest.mark.parametrize(
+    ("args", "expr", "filter"),
+    [
+        ((Session, SessionFilter, SessionStatus), "session_id = id", Session.session_id == "id"),
+        ((Session, SessionFilter, SessionStatus), "session_id != id", Session.session_id != "id"),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "session_id startswith id",
+            Session.session_id.startswith("id"),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "session_id endswith id",
+            Session.session_id.endswith("id"),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "session_id contains id",
+            Session.session_id.contains("id"),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "session_id notcontains id",
+            -Session.session_id.contains("id"),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "status = running",
+            Session.status == SessionStatus.RUNNING,
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "status != running",
+            Session.status != SessionStatus.RUNNING,
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "client_submission is true",
+            Session.client_submission,
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "client_submission is false",
+            -Session.client_submission,
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "partition_ids contains default",
+            Session.partition_ids.contains("default"),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "partition_ids notcontains default",
+            -Session.partition_ids.contains("default"),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "duration = 1:00:00",
+            Session.duration == timedelta(hours=1),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "duration = 15:00:00.10",
+            Session.duration == timedelta(hours=15, milliseconds=100),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "duration > 15:00:00.10",
+            Session.duration > timedelta(hours=15, milliseconds=100),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "created_at = 2024-12-28",
+            Session.created_at == datetime(year=2024, month=12, day=28),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "created_at = 2024-12-28T23:00:15",
+            Session.created_at
+            == datetime(year=2024, month=12, day=28, hour=23, minute=0, second=15),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "created_at != 2024-12-28T23:00:15",
+            Session.created_at
+            != datetime(year=2024, month=12, day=28, hour=23, minute=0, second=15),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "created_at > 2024-12-28T23:00:15",
+            Session.created_at
+            > datetime(year=2024, month=12, day=28, hour=23, minute=0, second=15),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "created_at >= 2024-12-28T23:00:15",
+            Session.created_at
+            >= datetime(year=2024, month=12, day=28, hour=23, minute=0, second=15),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "created_at < 2024-12-28T23:00:15",
+            Session.created_at
+            < datetime(year=2024, month=12, day=28, hour=23, minute=0, second=15),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "created_at <= 2024-12-28T23:00:15",
+            Session.created_at
+            <= datetime(year=2024, month=12, day=28, hour=23, minute=0, second=15),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus, True),
+            "options.application_name = name",
+            Session.options.application_name == "name",
+        ),
+        (
+            (Session, SessionFilter, SessionStatus, True),
+            "options.priority = 1",
+            Session.options.priority == 1,
+        ),
+        (
+            (Session, SessionFilter, SessionStatus, True),
+            "options[key] = value",
+            Session.options["key"] == "value",
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "session_id = id and status != running",
+            (Session.session_id == "id") & (Session.status != SessionStatus.RUNNING),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "session_id = id or status != running",
+            (Session.session_id == "id") | (Session.status != SessionStatus.RUNNING),
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "session_id = id and status != running or session_id startswith ok",
+            (Session.session_id == "id") & (Session.status != SessionStatus.RUNNING)
+            | (Session.session_id.startswith("ok")),
+        ),
+        (
+            (Result, ResultFilter, ResultStatus),
+            "size >= 5000",
+            Result.size >= 5000,
+        ),
+        (
+            (Task, TaskFilter, TaskStatus),
+            "owner_pod_id = pod-id",
+            Task.owner_pod_id == "pod-id",
+        ),
+        (
+            (Task, TaskFilter, TaskStatus, True),
+            "options.application_name = app_name",
+            Task.options.application_name == "app_name",
+        ),
+        (
+            (Task, TaskFilter, TaskStatus, True),
+            "options.application_name = ''",
+            Task.options.application_name == "",
+        ),
+        (
+            (Task, TaskFilter, TaskStatus, True, True),
+            "output.error contains 'an error occured'",
+            Task.output.error.contains("an error occured"),
+        ),
+        (
+            (Partition, PartitionFilter),
+            "priority = 1",
+            Partition.priority == 1,
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "client_submission",
+            Session.client_submission,
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            "not client_submission",
+            -Session.client_submission,
+        ),
+        (
+            (Session, SessionFilter, SessionStatus),
+            '!(client_submission AND session_id = "id")',
+            -(Session.client_submission & (Session.session_id == "id")),
+        ),
+    ],
+)
+def test_filter_parser(args, expr, filter):
+    assert FilterParser(*args).parse(expr).to_dict() == filter.to_dict()

--- a/tests/core/test_params.py
+++ b/tests/core/test_params.py
@@ -3,7 +3,9 @@ import pytest
 
 from datetime import timedelta
 
-from armonik_cli.core import KeyValuePairParam, TimeDeltaParam
+from armonik.common import Partition, Result, Session, Task
+
+from armonik_cli.core import KeyValuePairParam, TimeDeltaParam, FilterParam
 
 
 @pytest.mark.parametrize(
@@ -39,3 +41,28 @@ def test_timedelta_parm_success(input, output):
 def test_timedelta_parm_fail(input):
     with pytest.raises(click.BadParameter):
         assert TimeDeltaParam().convert(input, None, None)
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "input", "output"),
+    [
+        ("Task", "output.error contains 'an error'", Task.output.error.contains("an error")),
+        ("Session", "options['key'] = value", Session.options["key"] == "value"),
+        ("Result", "result_id = id", Result.result_id == "id"),
+        ("Partition", "id = id", Partition.id == "id"),
+    ],
+)
+def test_filter_parm_success(filter_type, input, output):
+    assert FilterParam(filter_type).convert(input, None, None).to_dict() == output.to_dict()
+
+
+@pytest.mark.parametrize(
+    ("filter_type", "input"),
+    [
+        ("Task", "id = string with space"),
+        ("Result", 'size = "1"'),
+    ],
+)
+def test_filter_parm_fail(filter_type, input):
+    with pytest.raises(click.BadParameter):
+        assert FilterParam(filter_type).convert(input, None, None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,32 @@
+import pytest
+
+from datetime import timedelta
+
+from armonik_cli.utils import parse_time_delta, remove_string_delimiters
+
+
+@pytest.mark.parametrize(
+    ("input", "output"),
+    [
+        ("15.12:11:10", timedelta(days=15, hours=12, minutes=11, seconds=10)),
+        ("15.12:11:10.987", timedelta(days=15, hours=12, minutes=11, seconds=10, milliseconds=987)),
+        ("12:11:10.987", timedelta(hours=12, minutes=11, seconds=10, milliseconds=987)),
+        ("12:11:10", timedelta(hours=12, minutes=11, seconds=10)),
+        ("0:10:0", timedelta(minutes=10)),
+        ("-0:10:0", -timedelta(minutes=10)),
+    ],
+)
+def test_parse_time_delta(input, output):
+    assert parse_time_delta(input) == output
+
+
+@pytest.mark.parametrize(
+    ("input", "output"),
+    [
+        ("'test string'", "test string"),
+        ('"test string"', "test string"),
+        ("test string", "test string"),
+    ],
+)
+def test_remove_string_delimiters(input, output):
+    remove_string_delimiters(input) == output


### PR DESCRIPTION
# Motivation

The current version of the CLI does not provide filtering support for list queries.

# Description

The implemented solution uses a custom parser built from a grammar adapted to the filter description. The parser constructs an AST, which is then traversed and transformed into a filter. This logic is then encapsulated in a custom Click parmeter type.

# Testing

A large number of unit tests have been added to validate the implementation.

# Impact

Modifications are fully backward-compatible.

# Additional Information

No.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
