### PR TITLE
fix: Error handler always prints out the error message when available else the traceback

### DIFF
--- a/src/armonik_cli/core/decorators.py
+++ b/src/armonik_cli/core/decorators.py
@@ -30,16 +30,19 @@ def error_handler(func=None):
         except grpc.RpcError as err:
             status_code = err.code()
             error_details = f"{err.details()}."
-
+            click.echo(
+                click.style(
+                    f"Failed with error:\n[status_code={status_code.name}]: {error_details}", "red"
+                )
+            )
+            if "debug" in kwargs and kwargs["debug"]:
+                console.print_exception()
             if status_code == grpc.StatusCode.NOT_FOUND:
                 raise NotFoundError(error_details)
             else:
                 raise InternalError("An internal fatal error occured.")
         except Exception:
-            if "debug" in kwargs and kwargs["debug"]:
-                console.print_exception()
-            else:
-                raise InternalError("An internal fatal error occured.")
+            console.print_exception()
 
     return wrapper
 


### PR DESCRIPTION

# Motivation

the error_handler captures and obfuscates errors unless `--debug` is passed.

# Description

This PR makes it so it spits out the error message instead of "Internal Error" when said message exists (for gRPC for instance), and in the other case of a generic exception, it always prints the exception with the traceback which might make it easier for the user to understand what went wrong (Basically the behavior of passing in `--debug` in this case. Click continues to handle its own exceptions. 

# Testing

Not applicable.

# Impact

Not applicable.

# Additional Information

Not applicable.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
