### PR TITLE
feat: Added result commands

### DIFF
--- a/src/armonik_cli/cli.py
+++ b/src/armonik_cli/cli.py
@@ -17,3 +17,4 @@ def cli() -> None:
 cli.add_command(commands.sessions)
 cli.add_command(commands.tasks)
 cli.add_command(commands.partitions)
+cli.add_command(commands.results)

--- a/src/armonik_cli/commands/__init__.py
+++ b/src/armonik_cli/commands/__init__.py
@@ -1,6 +1,7 @@
 from .sessions import sessions
 from .tasks import tasks
 from .partitions import partitions
+from .results import results
 
 
-__all__ = ["sessions", "tasks", "partitions"]
+__all__ = ["sessions", "tasks", "partitions", "results"]

--- a/src/armonik_cli/commands/results.py
+++ b/src/armonik_cli/commands/results.py
@@ -1,0 +1,244 @@
+from collections import defaultdict
+import grpc
+import rich_click as click
+
+from typing import IO, List, Union
+
+from armonik.client.results import ArmoniKResults
+from armonik.common import Result, ResultStatus, Direction
+from armonik.common.filter import PartitionFilter, Filter
+
+from armonik_cli.core import console, base_command, base_group
+from armonik_cli.core.options import MutuallyExclusiveOption
+from armonik_cli.core.params import FieldParam, FilterParam, ResultNameDataParam
+
+
+RESULT_TABLE_COLS = [
+    ("Name", "Name"),
+    ("ID", "ResultId"),
+    ("Status", "Status"),
+    ("CreatedAt", "CreatedAt"),
+]  # These should be configurable (through Config)
+
+
+@click.group(name="result")
+@base_group
+def results() -> None:
+    """Manage results."""
+    pass
+
+
+@results.command(name="list")
+@click.option(
+    "-f",
+    "--filter",
+    "filter_with",
+    type=FilterParam("Result"),
+    required=False,
+    help="An expression to filter the listed results with.",
+    metavar="FILTER EXPR",
+)
+@click.option(
+    "--sort-by",
+    type=FieldParam("Result"),
+    required=False,
+    help="Attribute of result to sort with.",
+)
+@click.option(
+    "--sort-direction",
+    type=click.Choice(["asc", "desc"], case_sensitive=False),
+    default="asc",
+    required=False,
+    help="Whether to sort by ascending or by descending order.",
+)
+@click.option(
+    "--page", default=-1, help="Get a specific page, it defaults to -1 which gets all pages."
+)
+@click.option("--page-size", default=100, help="Number of elements in each page")
+@base_command
+def result_list(
+    endpoint: str,
+    output: str,
+    filter_with: Union[PartitionFilter, None],
+    sort_by: Filter,
+    sort_direction: str,
+    page: int,
+    page_size: int,
+    debug: bool,
+) -> None:
+    """List the results of an ArmoniK cluster given <SESSION-ID>."""
+    with grpc.insecure_channel(endpoint) as channel:
+        results_client = ArmoniKResults(channel)
+        curr_page = page if page > 0 else 0
+        results_list = []
+        while True:
+            total, results = results_client.list_results(
+                result_filter=filter_with,
+                sort_field=Result.name if sort_by is None else sort_by,
+                sort_direction=Direction.ASC
+                if sort_direction.capitalize() == "ASC"
+                else Direction.DESC,
+                page=curr_page,
+                page_size=page_size,
+            )
+
+            results_list += results
+            if page > 0 or len(results_list) >= total:
+                break
+            curr_page += 1
+
+    if total > 0:
+        results = [_clean_up_status(r) for r in results]
+        console.formatted_print(results, format=output, table_cols=RESULT_TABLE_COLS)
+
+
+@results.command(name="get")
+@click.argument("result-ids", type=str, nargs=-1, required=True)
+@base_command
+def result_get(endpoint: str, output: str, result_ids: List[str], debug: bool) -> None:
+    """Get details about multiple results given their RESULT_IDs."""
+    with grpc.insecure_channel(endpoint) as channel:
+        results_client = ArmoniKResults(channel)
+        results = []
+        for result_id in result_ids:
+            result = results_client.get_result(result_id)
+            result = _clean_up_status(result)
+            results.append(result)
+        console.formatted_print(results, format=output, table_cols=RESULT_TABLE_COLS)
+
+
+@results.command(name="create")
+@click.argument("session-id", type=str, required=True)
+@click.option(
+    "-r",
+    "--result",
+    "result_definitions",
+    type=ResultNameDataParam(),
+    required=True,
+    multiple=True,
+    help=(
+        "Results to create. You can pass:\n"
+        "1. --result <result_name> (only metadata is created).\n"
+        "2. --result '<result_name> bytes <bytes>' (data is provided in bytes).\n"
+        "3. --result '<result_name> file <filepath>' (data is provided from a file)."
+    ),
+)
+@base_command
+def result_create(
+    endpoint: str,
+    output: str,
+    result_definitions: List[ResultNameDataParam.ParamType],
+    session_id: str,
+    debug: bool,
+) -> None:
+    """Create result objects in a session with id SESSION_ID."""
+    results_with_data = dict()
+    metadata_only = []
+    for res in result_definitions:
+        if res.type == "bytes":
+            results_with_data[res.name] = res.data
+        elif res.type == "file":
+            with open(res.data, "rb") as file:
+                results_with_data[res.name] = file.read()
+        elif res.type == "nodata":
+            metadata_only.append(res.name)
+
+    with grpc.insecure_channel(endpoint) as channel:
+        results_client = ArmoniKResults(channel)
+        # Create metadata-only results
+        created_results = []
+        if len(metadata_only) > 0:
+            created_results_metadata_only = results_client.create_results_metadata(
+                result_names=metadata_only, session_id=session_id
+            )
+            created_results += created_results_metadata_only.values()
+        # Create results with data
+        if len(results_with_data.keys()) > 0:
+            created_results_data = results_client.create_results(
+                results_data=results_with_data, session_id=session_id
+            )
+            created_results += created_results_data.values()
+        created_results = [_clean_up_status(r) for r in created_results]
+        console.formatted_print(created_results, format=output, table_cols=RESULT_TABLE_COLS)
+
+
+@results.command(name="upload-data")
+@click.argument("session-id", type=str, required=True)
+@click.argument("result-id", type=str, required=True)
+@click.option(
+    "--from-bytes", type=str, cls=MutuallyExclusiveOption, mutual=["from_file"], require_one=True
+)
+@click.option(
+    "--from-file",
+    type=click.File("rb"),
+    cls=MutuallyExclusiveOption,
+    mutual=["from_bytes"],
+    require_one=True,
+)
+@base_command
+def result_upload_data(
+    endpoint: str,
+    output: str,
+    session_id: str,
+    result_id: Union[str, None],
+    from_bytes: Union[str, None],
+    from_file: IO[bytes],
+    debug: bool,
+) -> None:
+    """Upload data for a result separately"""
+    with grpc.insecure_channel(endpoint) as channel:
+        results_client = ArmoniKResults(channel)
+        if from_bytes:
+            result_data = bytes(from_bytes, encoding="utf-8")
+        if from_file:
+            result_data = from_file.read()
+
+        results_client.upload_result_data(result_id, session_id, result_data)
+
+
+@results.command(name="delete-data")
+@click.argument("result-ids", type=str, nargs=-1, required=True)
+@click.option(
+    "--confirm",
+    is_flag=True,
+    help="Confirm the deletion of all result data without needing to do so for each result.",
+)
+@click.option(
+    "--skip-not-found",
+    is_flag=True,
+    help="Skips results that haven't been found when trying to delete them.",
+)
+@base_command
+def result_delete_data(
+    endpoint: str,
+    output: str,
+    result_ids: List[str],
+    confirm: bool,
+    skip_not_found: bool,
+    debug: bool,
+) -> None:
+    """Delete the data of multiple results given their RESULT_IDs."""
+    with grpc.insecure_channel(endpoint) as channel:
+        results_client = ArmoniKResults(channel)
+        session_result_mapping = defaultdict(list)
+        for result_id in result_ids:
+            try:
+                result = results_client.get_result(result_id)
+            except grpc.RpcError as e:
+                if skip_not_found and e.code() == grpc.StatusCode.NOT_FOUND:
+                    console.print(f"Couldn't find result with id={result_id}, skipping...")
+                    continue
+                else:
+                    raise e
+            if confirm or click.confirm(
+                f"Are you sure you want to delete the result data of task [{result.owner_task_id}] in session [{result.session_id}]",
+                abort=False,
+            ):
+                session_result_mapping[result.session_id].append(result_id)
+        for session_id, result_ids_for_session in session_result_mapping.items():
+            results_client.delete_result_data(result_ids_for_session, session_id)
+
+
+def _clean_up_status(result: Result) -> Result:
+    result.status = ResultStatus.name_from_value(result.status).split("_")[-1].capitalize()
+    return result

--- a/src/armonik_cli/core/__init__.py
+++ b/src/armonik_cli/core/__init__.py
@@ -1,12 +1,20 @@
 from armonik_cli.core.console import console
 from armonik_cli.core.decorators import base_command, base_group
-from armonik_cli.core.params import KeyValuePairParam, TimeDeltaParam, FilterParam
+from armonik_cli.core.params import (
+    KeyValuePairParam,
+    TimeDeltaParam,
+    FilterParam,
+    ResultNameDataParam,
+    FieldParam,
+)
 
 
 __all__ = [
     "base_command",
     "KeyValuePairParam",
     "TimeDeltaParam",
+    "FieldParam",
+    "ResultNameDataParam",
     "FilterParam",
     "console",
     "base_group",

--- a/src/armonik_cli/core/options.py
+++ b/src/armonik_cli/core/options.py
@@ -1,6 +1,6 @@
 import rich_click as click
 
-from typing import Any
+from typing import Any, List, Tuple, Mapping
 
 
 class GlobalOption(click.Option):
@@ -43,3 +43,63 @@ class GlobalOption(click.Option):
         if not value and not isinstance(ctx.command, click.Group) and self.globally_required:
             raise click.MissingParameter(ctx=ctx)
         return value
+
+
+class MutuallyExclusiveOption(click.Option):
+    """
+    A custom Click option class that enforces mutual exclusivity between specified options
+    and optionally requires at least one of the mutual options to be passed.
+
+    Attributes:
+        mutual: A list of option names that cannot be used together with this option.
+        require_one: Whether at least one of the mutually exclusive options must be provided.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.mutual = set(kwargs.pop("mutual", []))
+        self.require_one = kwargs.pop("require_one", False)
+
+        if self.mutual:
+            mutual_text = f" This option cannot be used together with {' or '.join(self.mutual)}."
+            kwargs["help"] = f"{kwargs.get('help', '')}{mutual_text}"
+
+        if self.require_one:
+            kwargs["help"] = (
+                f"{kwargs.get('help', '')} At least one of these options must be provided."
+            )
+
+        super().__init__(*args, **kwargs)
+
+    def handle_parse_result(
+        self, ctx: click.Context, opts: Mapping[str, Any], args: List[str]
+    ) -> Tuple[Any, List[str]]:
+        """
+        Handle the parsing of command-line options, enforcing mutual exclusivity
+        and the requirement of at least one mutual option if specified.
+
+        Args:
+            ctx: The Click context.
+            opts: A dictionary of the parsed command-line options.
+            args: The remaining command-line arguments.
+
+        Returns:
+            The result of the superclass's `handle_parse_result` method.
+
+        Raises:
+            click.UsageError: If mutual exclusivity is violated or if none of the required options are provided.
+        """
+        mutex = self.mutual.intersection(opts)
+
+        # Enforce mutual exclusivity
+        if mutex and self.name in opts:
+            raise click.UsageError(
+                f"Illegal usage: `{self.name}` cannot be used together with '{', '.join(mutex)}'."
+            )
+
+        # Enforce that at least one mutual option is provided
+        if self.require_one and not mutex and self.name not in opts:
+            raise click.UsageError(
+                f"At least one of the following options must be provided: {', '.join(self.mutual)}."
+            )
+
+        return super().handle_parse_result(ctx, opts, args)

--- a/src/armonik_cli/core/serialize.py
+++ b/src/armonik_cli/core/serialize.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime, timedelta
 from typing import Dict, List, Union, Any
 
-from armonik.common import Session, TaskOptions, Task, Partition
+from armonik.common import Session, Task, TaskOptions, Partition, Result
 from google._upb._message import ScalarMapContainer, RepeatedScalarContainer
 
 
@@ -16,7 +16,7 @@ class CLIJSONEncoder(json.JSONEncoder):
         __api_types: The list of ArmoniK API Python objects managed by this encoder.
     """
 
-    __api_types = [Session, TaskOptions, Task, Partition]
+    __api_types = [Session, Task, TaskOptions, Partition, Result]
 
     def default(self, obj: object) -> Union[str, Dict[str, Any], List[Any]]:
         """

--- a/tests/commands/test_results.py
+++ b/tests/commands/test_results.py
@@ -1,0 +1,355 @@
+from copy import deepcopy
+from datetime import datetime
+from unittest.mock import Mock, mock_open
+import pytest
+
+from armonik.client.results import ArmoniKResults
+from armonik.common import Result, ResultStatus
+
+from conftest import run_cmd_and_assert_exit_code, reformat_cmd_output
+
+ENDPOINT = "172.17.119.85:5001"
+
+raw_results = [
+    Result(
+        session_id="5f723ff6-56e7-4329-a5d1-5e1f7ba6c7ef",
+        name="",
+        created_by="37b15f70-cacc-4ffd-8cbd-e5986f7edbb4",
+        owner_task_id="",
+        status=ResultStatus.DELETED,
+        created_at=datetime(year=2025, month=1, day=15),
+        completed_at=None,
+        result_id="e9cb3a53-e742-4ea5-b66b-8a0f9eb1f49d",
+        size=20910,
+    ),
+    Result(
+        session_id="5f723ff6-56e7-4329-a5d1-5e1f7ba6c7ef",
+        name="",
+        created_by="37b15f70-cacc-4ffd-8cbd-e5986f7edbb4",
+        owner_task_id="",
+        status=ResultStatus.DELETED,
+        created_at=datetime(year=2025, month=1, day=15),
+        completed_at=None,
+        result_id="cb0c7a4a-d7e7-4bea-bb0e-66c3628f9ac3",
+        size=20942,
+    ),
+]
+
+serialized_results = [
+    {
+        "SessionId": "5f723ff6-56e7-4329-a5d1-5e1f7ba6c7ef",
+        "Name": "",
+        "CreatedBy": "37b15f70-cacc-4ffd-8cbd-e5986f7edbb4",
+        "OwnerTaskId": "",
+        "Status": "Deleted",
+        "CreatedAt": "2025-01-15 00:00:00",
+        "CompletedAt": None,
+        "ResultId": "e9cb3a53-e742-4ea5-b66b-8a0f9eb1f49d",
+        "Size": 20910,
+    },
+    {
+        "SessionId": "5f723ff6-56e7-4329-a5d1-5e1f7ba6c7ef",
+        "Name": "",
+        "CreatedBy": "37b15f70-cacc-4ffd-8cbd-e5986f7edbb4",
+        "OwnerTaskId": "",
+        "Status": "Deleted",
+        "CreatedAt": "2025-01-15 00:00:00",
+        "CompletedAt": None,
+        "ResultId": "cb0c7a4a-d7e7-4bea-bb0e-66c3628f9ac3",
+        "Size": 20942,
+    },
+]
+
+
+@pytest.mark.parametrize("cmd", [f"result list -e {ENDPOINT} -f session_id=id"])
+def test_result_list(mocker, cmd):
+    mocker.patch.object(ArmoniKResults, "list_results", return_value=(2, deepcopy(raw_results)))
+    result = run_cmd_and_assert_exit_code(cmd)
+    assert reformat_cmd_output(result.output, deserialize=True) == serialized_results
+
+
+@pytest.mark.parametrize(
+    "cmd, expected_output",
+    [
+        (
+            f"result get --endpoint {ENDPOINT} {serialized_results[0]['ResultId']}",
+            [serialized_results[0]],
+        ),
+        (
+            f"result get --endpoint {ENDPOINT} {serialized_results[0]['ResultId']} {serialized_results[1]['ResultId']}",
+            [serialized_results[0], serialized_results[1]],
+        ),
+    ],
+)
+def test_result_get(mocker, cmd, expected_output):
+    def get_result_side_effect(result_id):
+        if result_id == serialized_results[0]["ResultId"]:
+            return deepcopy(raw_results[0])
+        elif result_id == serialized_results[1]["ResultId"]:
+            return deepcopy(raw_results[1])
+
+    mocker.patch.object(ArmoniKResults, "get_result", side_effect=get_result_side_effect)
+    result = run_cmd_and_assert_exit_code(cmd)
+    assert reformat_cmd_output(result.output, deserialize=True) == expected_output
+
+
+@pytest.mark.parametrize(
+    "cmd, expected_output",
+    [
+        (
+            f"result delete-data --endpoint {ENDPOINT} {serialized_results[0]['ResultId']} --confirm --debug",
+            {serialized_results[0]["SessionId"]: [serialized_results[0]["ResultId"]]},
+        ),
+        (
+            f"result delete-data --endpoint {ENDPOINT} {serialized_results[0]['ResultId']} {serialized_results[1]['ResultId']} --confirm --debug",
+            {
+                serialized_results[0]["SessionId"]: [
+                    serialized_results[0]["ResultId"],
+                    serialized_results[1]["ResultId"],
+                ]
+            },
+        ),
+    ],
+)
+def test_result_delete_data(mocker, cmd, expected_output):
+    def get_result_side_effect(result_id):
+        if result_id == serialized_results[0]["ResultId"]:
+            return deepcopy(raw_results[0])
+        elif result_id == serialized_results[1]["ResultId"]:
+            return deepcopy(raw_results[1])
+        raise ValueError(f"Unexpected result_id: {result_id}")
+
+    # Create a mock channel that supports context manager
+    mock_channel = Mock()
+    mock_channel.__enter__ = Mock(return_value=mock_channel)
+    mock_channel.__exit__ = Mock(return_value=None)
+
+    # Patch the channel first
+    mocker.patch("grpc.insecure_channel", return_value=mock_channel)
+
+    # Patch the methods on ArmoniKResults class itself
+    mocker.patch.object(ArmoniKResults, "get_result", side_effect=get_result_side_effect)
+    mocker.patch.object(ArmoniKResults, "delete_result_data")
+
+    # Run the command
+    run_cmd_and_assert_exit_code(cmd)
+
+    # Get the instance that was created during the test
+    ArmonikResults_instance = ArmoniKResults.delete_result_data
+    ArmonikResults_instance.assert_called_once_with(
+        expected_output[serialized_results[0]["SessionId"]], serialized_results[0]["SessionId"]
+    )
+
+
+def test_result_create_file_not_found(mocker):
+    # Create a mock channel that supports context manager
+    mock_channel = Mock()
+    mock_channel.__enter__ = Mock(return_value=mock_channel)
+    mock_channel.__exit__ = Mock(return_value=None)
+
+    # Patch the channel creation
+    mocker.patch("grpc.insecure_channel", return_value=mock_channel)
+
+    # Mock file operations to raise FileNotFoundError
+    mocker.patch("builtins.open", side_effect=FileNotFoundError)
+
+    # Run the command and expect it to fail
+    run_cmd_and_assert_exit_code(
+        [
+            "result",
+            "create",
+            "my-session-id",
+            "-r",
+            "res file nonexistent",
+            "--endpoint",
+            ENDPOINT,
+            "--debug",
+        ],
+        split=False,
+        exit_code=2,
+    )
+
+
+def test_result_create_metadata_only(mocker):
+    # Create a mock channel that supports context manager
+    mock_channel = Mock()
+    mock_channel.__enter__ = Mock(return_value=mock_channel)
+    mock_channel.__exit__ = Mock(return_value=None)
+
+    # Patch the channel creation
+    mocker.patch("grpc.insecure_channel", return_value=mock_channel)
+
+    # Patch the methods on ArmoniKResults class
+    mocker.patch.object(ArmoniKResults, "create_results_metadata", return_value={})
+    mocker.patch.object(ArmoniKResults, "create_results", return_value={})
+
+    cmd = [
+        "result",
+        "create",
+        "my-session-id",
+        "--result",
+        "result1",
+        "--result",
+        "result2",
+        "--endpoint",
+        ENDPOINT,
+    ]
+    run_cmd_and_assert_exit_code(cmd, split=False)
+
+    ArmoniKResults.create_results_metadata.assert_called_once_with(
+        session_id="my-session-id", result_names=["result1", "result2"]
+    )
+    ArmoniKResults.create_results.assert_not_called()
+
+
+def test_result_create_with_bytes(mocker):
+    # Create a mock channel that supports context manager
+    mock_channel = Mock()
+    mock_channel.__enter__ = Mock(return_value=mock_channel)
+    mock_channel.__exit__ = Mock(return_value=None)
+
+    # Patch the channel creation
+    mocker.patch("grpc.insecure_channel", return_value=mock_channel)
+
+    # Patch the methods on ArmoniKResults class
+    mocker.patch.object(ArmoniKResults, "create_results_metadata", return_value={})
+    mocker.patch.object(ArmoniKResults, "create_results", return_value={})
+
+    cmd = [
+        "result",
+        "create",
+        "my-session-id",
+        "--result",
+        "result1 bytes hello",
+        "--result",
+        "result2 bytes world",
+        "--endpoint",
+        ENDPOINT,
+    ]
+    run_cmd_and_assert_exit_code(cmd, split=False)
+
+    ArmoniKResults.create_results_metadata.assert_not_called()
+    ArmoniKResults.create_results.assert_called_once_with(
+        session_id="my-session-id", results_data={"result1": b"hello", "result2": b"world"}
+    )
+
+
+def test_result_create_mixed(mocker):
+    # Create a mock channel that supports context manager
+    mock_channel = Mock()
+    mock_channel.__enter__ = Mock(return_value=mock_channel)
+    mock_channel.__exit__ = Mock(return_value=None)
+
+    # Patch the channel creation
+    mocker.patch("grpc.insecure_channel", return_value=mock_channel)
+
+    # Patch the methods on ArmoniKResults class
+    mocker.patch.object(ArmoniKResults, "create_results_metadata", return_value={})
+    mocker.patch.object(ArmoniKResults, "create_results", return_value={})
+
+    cmd = [
+        "result",
+        "create",
+        "my-session-id",
+        "--result",
+        "result1",
+        "--result",
+        "result2 bytes hello",
+        "--endpoint",
+        ENDPOINT,
+    ]
+    run_cmd_and_assert_exit_code(cmd, split=False)
+
+    ArmoniKResults.create_results_metadata.assert_called_once_with(
+        session_id="my-session-id", result_names=["result1"]
+    )
+    ArmoniKResults.create_results.assert_called_once_with(
+        session_id="my-session-id", results_data={"result2": b"hello"}
+    )
+
+
+def test_result_upload_data_from_bytes(mocker):
+    # Create a mock channel that supports context manager
+    mock_channel = Mock()
+    mock_channel.__enter__ = Mock(return_value=mock_channel)
+    mock_channel.__exit__ = Mock(return_value=None)
+
+    # Patch the channel creation
+    mocker.patch("grpc.insecure_channel", return_value=mock_channel)
+
+    # Patch the methods on ArmoniKResults class
+    mocker.patch.object(ArmoniKResults, "upload_result_data", return_value=None)
+
+    cmd = [
+        "result",
+        "upload-data",
+        "my-session-id",
+        "result-id",
+        "--from-bytes",
+        "hello",
+        "--endpoint",
+        ENDPOINT,
+    ]
+    run_cmd_and_assert_exit_code(cmd, split=False)
+
+    ArmoniKResults.upload_result_data.assert_called_once_with(
+        "result-id", "my-session-id", b"hello"
+    )
+
+
+def test_result_upload_data_from_file(mocker):
+    # Create a mock channel that supports context manager
+    mock_channel = Mock()
+    mock_channel.__enter__ = Mock(return_value=mock_channel)
+    mock_channel.__exit__ = Mock(return_value=None)
+
+    # Patch the channel creation
+    mocker.patch("grpc.insecure_channel", return_value=mock_channel)
+
+    # Patch the methods on ArmoniKResults class
+    mocker.patch.object(ArmoniKResults, "upload_result_data", return_value=None)
+
+    # Mock file operations
+    mock_file_content = b"file content"
+    mocker.patch("builtins.open", mock_open(read_data=mock_file_content))
+
+    cmd = [
+        "result",
+        "upload-data",
+        "my-session-id",
+        "result-id",
+        "--from-file",
+        "test.txt",
+        "--endpoint",
+        ENDPOINT,
+    ]
+    run_cmd_and_assert_exit_code(cmd, split=False)
+
+    ArmoniKResults.upload_result_data.assert_called_once_with(
+        "result-id", "my-session-id", mock_file_content
+    )
+
+
+def test_result_upload_data_file_not_found(mocker):
+    # Create a mock channel that supports context manager
+    mock_channel = Mock()
+    mock_channel.__enter__ = Mock(return_value=mock_channel)
+    mock_channel.__exit__ = Mock(return_value=None)
+
+    # Patch the channel creation
+    mocker.patch("grpc.insecure_channel", return_value=mock_channel)
+
+    # Mock file operations to raise FileNotFoundError
+    mocker.patch("builtins.open", side_effect=FileNotFoundError)
+
+    cmd = [
+        "result",
+        "upload-data",
+        "my-session-id",
+        "result-id",
+        "--from-file",
+        "nonexistent.txt",
+        "--endpoint",
+        ENDPOINT,
+    ]
+    run_cmd_and_assert_exit_code(cmd, split=False, exit_code=2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,14 @@ from armonik_cli.cli import cli
 
 
 def run_cmd_and_assert_exit_code(
-    cmd: str, exit_code: int = 0, input: Optional[str] = None, env: Optional[Dict[str, str]] = None
+    cmd: str,
+    exit_code: int = 0,
+    input: Optional[str] = None,
+    env: Optional[Dict[str, str]] = None,
+    split: bool = True,
 ) -> Result:
-    cmd = cmd.split()
+    if split:
+        cmd = cmd.split()
     runner = CliRunner()
     with runner.isolated_filesystem():
         result = runner.invoke(cli, cmd, input=input, env=env)

--- a/tests/core/test_params.py
+++ b/tests/core/test_params.py
@@ -2,12 +2,19 @@ import click
 import pytest
 
 from datetime import timedelta
+from unittest.mock import patch
+from pathlib import Path
 
 from armonik.common import Partition, Result, Session, Task
 from armonik.common.filter.filter import StringFilter
 
-from armonik_cli.core import KeyValuePairParam, TimeDeltaParam, FilterParam
-from armonik_cli.core.params import FieldParam
+from armonik_cli.core import (
+    KeyValuePairParam,
+    TimeDeltaParam,
+    FilterParam,
+    FieldParam,
+    ResultNameDataParam,
+)
 
 
 @pytest.mark.parametrize(
@@ -77,7 +84,7 @@ def test_filter_parm_fail(filter_type, input):
         ("Session", "options"),
     ],
 )
-def test_field_param_invalid(mocker, base_struct, field_name):
+def test_field_param_invalid(base_struct, field_name):
     with pytest.raises(click.BadParameter):
         FieldParam(base_struct).convert(field_name, None, None)
 
@@ -89,6 +96,50 @@ def test_field_param_invalid(mocker, base_struct, field_name):
         ("Session", "session_id"),
     ],
 )
-def test_field_param_valid(mocker, base_struct, field_name):
+def test_field_param_valid(base_struct, field_name):
     res = FieldParam(base_struct).convert(field_name, None, None)
     assert type(res) is StringFilter
+
+
+def test_convert_single_value():
+    param_type = ResultNameDataParam()
+    result = param_type.convert("test_value", None, None)
+    assert result == param_type.ParamType("test_value", "nodata", None)
+
+
+def test_convert_bytes_data():
+    param_type = ResultNameDataParam()
+    result = param_type.convert("name bytes data", None, None)
+    assert result == param_type.ParamType("name", "bytes", b"data")
+
+
+def test_convert_valid_file():
+    param_type = ResultNameDataParam()
+    with patch.object(Path, "is_file", return_value=True):
+        result = param_type.convert("name file /valid/path.txt", None, None)
+        assert result == param_type.ParamType("name", "file", "/valid/path.txt")
+
+
+def test_convert_invalid_file():
+    param_type = ResultNameDataParam()
+    with patch.object(Path, "is_file", return_value=False):
+        with pytest.raises(click.BadParameter, match=r"Couldn't find the file "):
+            param_type.convert("name file /invalid/path.txt", None, None)
+
+
+def test_convert_invalid_type():
+    param_type = ResultNameDataParam()
+    with pytest.raises(click.BadParameter, match=r"Invalid type 'unknown'"):
+        param_type.convert("name unknown data", None, None)
+
+
+def test_convert_empty_value():
+    param_type = ResultNameDataParam()
+    result = param_type.convert("", None, None)
+    assert result is None
+
+
+def test_convert_malformed_input():
+    param_type = ResultNameDataParam()
+    result = param_type.convert("malformed input with too many parts", None, None)
+    assert result is None


### PR DESCRIPTION
# Motivation

The current version of the CLI doesn't have result-specific commands.

# Description

Added commands for : 
- Listing results
- Getting details about results
- Creating results
- Deleting result data
- Uploading data to results

Along with a parameter type for parsing result inputs.

# Testing

Unit testing for different failing scenarios, serialization and commandline argument parsing.

# Impact

Not applicable.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
