### PR TITLE
fix: Changed the FieldParam from Task to Partition

### DIFF
--- a/src/armonik_cli/commands/partitions.py
+++ b/src/armonik_cli/commands/partitions.py
@@ -31,7 +31,7 @@ def partitions() -> None:
 )
 @click.option(
     "--sort-by",
-    type=FieldParam("Task"),
+    type=FieldParam("Partition"),
     required=False,
     help="Attribute of partition to sort with.",
 )


### PR DESCRIPTION
# Motivation

Sorting would fail on using --sort-by because it would expect Task attributes.

# Description

Changed the FieldParam parameter.

# Testing

Command run succeeds, tested locally.

# Impact

Not applicable.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
