### PR TITLE
refactor: changed names of functions to avoid overriding builtins

### DIFF
--- a/src/armonik_cli/commands/partitions.py
+++ b/src/armonik_cli/commands/partitions.py
@@ -19,7 +19,7 @@ def partitions() -> None:
     pass
 
 
-@partitions.command()
+@partitions.command(name="list")
 @click.option(
     "-f",
     "--filter",
@@ -47,7 +47,7 @@ def partitions() -> None:
 )
 @click.option("--page-size", default=100, help="Number of elements in each page")
 @base_command
-def list(
+def partition_list(
     endpoint: str,
     output: str,
     filter_with: Union[PartitionFilter, None],
@@ -83,10 +83,10 @@ def list(
             )
 
 
-@partitions.command()
+@partitions.command(name="get")
 @click.argument("partition-ids", type=str, nargs=-1, required=True)
 @base_command
-def get(endpoint: str, output: str, partition_ids: List[str], debug: bool) -> None:
+def partition_get(endpoint: str, output: str, partition_ids: List[str], debug: bool) -> None:
     """Get a specific partition from an ArmoniK cluster given a <PARTITION-ID>."""
     with grpc.insecure_channel(endpoint) as channel:
         partitions_client = ArmoniKPartitions(channel)

--- a/src/armonik_cli/commands/sessions.py
+++ b/src/armonik_cli/commands/sessions.py
@@ -21,7 +21,7 @@ def sessions() -> None:
     pass
 
 
-@sessions.command()
+@sessions.command(name="list")
 @click.option(
     "-f",
     "--filter",
@@ -31,7 +31,9 @@ def sessions() -> None:
     metavar="FILTER EXPR",
 )
 @base_command
-def list(endpoint: str, output: str, filter: Union[SessionFilter, None], debug: bool) -> None:
+def session_list(
+    endpoint: str, output: str, filter: Union[SessionFilter, None], debug: bool
+) -> None:
     """List the sessions of an ArmoniK cluster."""
     with grpc.insecure_channel(endpoint) as channel:
         sessions_client = ArmoniKSessions(channel)
@@ -45,10 +47,10 @@ def list(endpoint: str, output: str, filter: Union[SessionFilter, None], debug: 
     # console.print(f"\n{total} sessions found.")
 
 
-@sessions.command()
+@sessions.command(name="get")
 @session_argument
 @base_command
-def get(endpoint: str, output: str, session_id: str, debug: bool) -> None:
+def session_get(endpoint: str, output: str, session_id: str, debug: bool) -> None:
     """Get details of a given session."""
     with grpc.insecure_channel(endpoint) as channel:
         sessions_client = ArmoniKSessions(channel)
@@ -57,7 +59,7 @@ def get(endpoint: str, output: str, session_id: str, debug: bool) -> None:
         console.formatted_print(session, format=output, table_cols=SESSION_TABLE_COLS)
 
 
-@sessions.command()
+@sessions.command(name="create")
 @click.option(
     "--max-retries",
     type=int,
@@ -126,7 +128,7 @@ def get(endpoint: str, output: str, session_id: str, debug: bool) -> None:
     metavar="KEY=VALUE",
 )
 @base_command
-def create(
+def session_create(
     endpoint: str,
     max_retries: int,
     max_duration: timedelta,
@@ -165,11 +167,11 @@ def create(
         console.formatted_print(session, format=output, table_cols=SESSION_TABLE_COLS)
 
 
-@sessions.command()
+@sessions.command(name="cancel")
 @click.confirmation_option("--confirm", prompt="Are you sure you want to cancel this session?")
 @session_argument
 @base_command
-def cancel(endpoint: str, output: str, session_id: str, debug: bool) -> None:
+def session_cancel(endpoint: str, output: str, session_id: str, debug: bool) -> None:
     """Cancel a session."""
     with grpc.insecure_channel(endpoint) as channel:
         sessions_client = ArmoniKSessions(channel)
@@ -178,10 +180,10 @@ def cancel(endpoint: str, output: str, session_id: str, debug: bool) -> None:
         console.formatted_print(session, format=output, table_cols=SESSION_TABLE_COLS)
 
 
-@sessions.command()
+@sessions.command(name="pause")
 @session_argument
 @base_command
-def pause(endpoint: str, output: str, session_id: str, debug: bool) -> None:
+def session_pause(endpoint: str, output: str, session_id: str, debug: bool) -> None:
     """Pause a session."""
     with grpc.insecure_channel(endpoint) as channel:
         sessions_client = ArmoniKSessions(channel)
@@ -190,10 +192,10 @@ def pause(endpoint: str, output: str, session_id: str, debug: bool) -> None:
         console.formatted_print(session, format=output, table_cols=SESSION_TABLE_COLS)
 
 
-@sessions.command()
+@sessions.command(name="resume")
 @session_argument
 @base_command
-def resume(endpoint: str, output: str, session_id: str, debug: bool) -> None:
+def session_resume(endpoint: str, output: str, session_id: str, debug: bool) -> None:
     """Resume a session."""
     with grpc.insecure_channel(endpoint) as channel:
         sessions_client = ArmoniKSessions(channel)
@@ -202,11 +204,11 @@ def resume(endpoint: str, output: str, session_id: str, debug: bool) -> None:
         console.formatted_print(session, format=output, table_cols=SESSION_TABLE_COLS)
 
 
-@sessions.command()
+@sessions.command(name="close")
 @click.confirmation_option("--confirm", prompt="Are you sure you want to close this session?")
 @session_argument
 @base_command
-def close(endpoint: str, output: str, session_id: str, debug: bool) -> None:
+def session_close(endpoint: str, output: str, session_id: str, debug: bool) -> None:
     """Close a session."""
     with grpc.insecure_channel(endpoint) as channel:
         sessions_client = ArmoniKSessions(channel)
@@ -215,11 +217,11 @@ def close(endpoint: str, output: str, session_id: str, debug: bool) -> None:
         console.formatted_print(session, format=output, table_cols=SESSION_TABLE_COLS)
 
 
-@sessions.command()
+@sessions.command(name="purge")
 @click.confirmation_option("--confirm", prompt="Are you sure you want to purge this session?")
 @session_argument
 @base_command
-def purge(endpoint: str, output: str, session_id: str, debug: bool) -> None:
+def session_purge(endpoint: str, output: str, session_id: str, debug: bool) -> None:
     """Purge a session."""
     with grpc.insecure_channel(endpoint) as channel:
         sessions_client = ArmoniKSessions(channel)
@@ -228,11 +230,11 @@ def purge(endpoint: str, output: str, session_id: str, debug: bool) -> None:
         console.formatted_print(session, format=output, table_cols=SESSION_TABLE_COLS)
 
 
-@sessions.command()
+@sessions.command(name="delete")
 @click.confirmation_option("--confirm", prompt="Are you sure you want to delete this session?")
 @session_argument
 @base_command
-def delete(endpoint: str, output: str, session_id: str, debug: bool) -> None:
+def session_delete(endpoint: str, output: str, session_id: str, debug: bool) -> None:
     """Delete a session and associated data from the cluster."""
     with grpc.insecure_channel(endpoint) as channel:
         sessions_client = ArmoniKSessions(channel)
@@ -241,7 +243,7 @@ def delete(endpoint: str, output: str, session_id: str, debug: bool) -> None:
         console.formatted_print(session, format=output, table_cols=SESSION_TABLE_COLS)
 
 
-@sessions.command()
+@sessions.command(name="stop-submission")
 @click.option(
     "--clients-only",
     is_flag=True,
@@ -256,7 +258,7 @@ def delete(endpoint: str, output: str, session_id: str, debug: bool) -> None:
 )
 @session_argument
 @base_command
-def stop_submission(
+def session_stop_submission(
     endpoint: str, session_id: str, clients_only: bool, workers_only: bool, output: str, debug: bool
 ) -> None:
     """Stop clients and/or workers from submitting new tasks in a session."""

--- a/src/armonik_cli/commands/tasks.py
+++ b/src/armonik_cli/commands/tasks.py
@@ -21,7 +21,7 @@ def tasks() -> None:
     pass
 
 
-@tasks.command()
+@tasks.command(name="list")
 @click.argument("session-id", required=True, type=str)
 @click.option(
     "-f",
@@ -47,7 +47,7 @@ def tasks() -> None:
 )
 @click.option("--page-size", default=100, help="Number of elements in each page")
 @base_command
-def list(
+def tasks_list(
     endpoint: str,
     output: str,
     session_id: str,
@@ -77,7 +77,7 @@ def list(
             )
             tasks_list += curr_tasks_list
 
-            if page >= 0 or total < page_size or curr_page > (total // page_size):
+            if page > 0 or len(tasks_list) >= total:
                 break
             curr_page += 1
 
@@ -86,10 +86,10 @@ def list(
         console.formatted_print(tasks_list, format=output, table_cols=TASKS_TABLE_COLS)
 
 
-@tasks.command()
+@tasks.command(name="get")
 @click.argument("task-ids", type=str, nargs=-1, required=True)
 @base_command
-def get(endpoint: str, output: str, task_ids: List[str], debug: bool):
+def tasks_get(endpoint: str, output: str, task_ids: List[str], debug: bool):
     """Get a detailed overview of set of tasks given their ids."""
     with grpc.insecure_channel(endpoint) as channel:
         tasks_client = ArmoniKTasks(channel)
@@ -101,17 +101,17 @@ def get(endpoint: str, output: str, task_ids: List[str], debug: bool):
         console.formatted_print(tasks, format=output, table_cols=TASKS_TABLE_COLS)
 
 
-@tasks.command()
+@tasks.command(name="cancel")
 @click.argument("task-ids", type=str, nargs=-1, required=True)
 @base_command
-def cancel(endpoint: str, output: str, task_ids: List[str], debug: bool):
+def tasks_cancel(endpoint: str, output: str, task_ids: List[str], debug: bool):
     "Cancel tasks given their ids. (They don't have to be in the same session necessarily)."
     with grpc.insecure_channel(endpoint) as channel:
         tasks_client = ArmoniKTasks(channel)
         tasks_client.cancel_tasks(task_ids)
 
 
-@tasks.command()
+@tasks.command(name="create")
 @click.option(
     "--session-id",
     type=str,
@@ -198,7 +198,7 @@ def cancel(endpoint: str, output: str, task_ids: List[str], debug: bool):
     metavar="KEY=VALUE",
 )
 @base_command
-def create(
+def tasks_create(
     endpoint: str,
     output: str,
     session_id: str,


### PR DESCRIPTION
# Motivation

Adopted a new standard where functions implementing command `command` are prefixed by the group (`group_command`) to avoid overriding Python's builtin functions (such as "list" or "set") as that can cause unexpected behavior.

# Description

- Changed the names of the different functions 
- Changed condition on Tasks list command 

# Testing

Code refactor, all tests still pass.

# Impact

Have to reinforce the naming standard.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
