### PR TITLE
fix: session-id is no longer a required argument for task list command

### DIFF
--- a/src/armonik_cli/commands/tasks.py
+++ b/src/armonik_cli/commands/tasks.py
@@ -22,7 +22,6 @@ def tasks() -> None:
 
 
 @tasks.command(name="list")
-@click.argument("session-id", required=True, type=str)
 @click.option(
     "-f",
     "--filter",
@@ -50,7 +49,6 @@ def tasks() -> None:
 def tasks_list(
     endpoint: str,
     output: str,
-    session_id: str,
     filter_with: Union[TaskFilter, None],
     sort_by: Filter,
     sort_direction: str,
@@ -58,16 +56,14 @@ def tasks_list(
     page_size: int,
     debug: bool,
 ) -> None:
-    "List all tasks for a session with id <SESSION_ID>."
+    "List all tasks."
     with grpc.insecure_channel(endpoint) as channel:
         tasks_client = ArmoniKTasks(channel)
         curr_page = page if page > 0 else 0
         tasks_list = []
         while True:
             total, curr_tasks_list = tasks_client.list_tasks(
-                task_filter=(Task.session_id == session_id) & filter_with
-                if filter_with is not None
-                else (Task.session_id == session_id),
+                task_filter=filter_with,
                 sort_field=Task.id if sort_by is None else sort_by,
                 sort_direction=Direction.ASC
                 if sort_direction.capitalize() == "ASC"

--- a/tests/commands/test_tasks.py
+++ b/tests/commands/test_tasks.py
@@ -219,7 +219,7 @@ serialized_tasks = [
 ]
 
 
-@pytest.mark.parametrize("cmd", [f"task list id -e {ENDPOINT} --debug"])
+@pytest.mark.parametrize("cmd", [f"task list -e {ENDPOINT} --debug"])
 def test_task_list(mocker, cmd):
     mocker.patch.object(ArmoniKTasks, "list_tasks", return_value=(2, deepcopy(raw_tasks)))
     result = run_cmd_and_assert_exit_code(cmd)


### PR DESCRIPTION
# Motivation

Filters already allow you to specify session_id, moreover, we can imagine use cases where you might want to list all tasks regardless of what session they belong to (all tasks that have failed).

# Description

- Removed session-id as a parameter from `task list`

# Testing

Changed unit tests, tests pass locally and in CI

# Impact

Not applicable.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
