### PR TITLE
feat: add global option support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "lark",
     "PyYAML",
     "rich_click",
+    "typing_extensions",
 ]
 
 [project.urls]

--- a/src/armonik_cli/cli.py
+++ b/src/armonik_cli/cli.py
@@ -1,10 +1,12 @@
 import rich_click as click
 
 from armonik_cli import commands, __version__
+from armonik_cli.core import base_group
 
 
 @click.group(name="armonik", context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=__version__, prog_name="armonik")
+@base_group
 def cli() -> None:
     """
     ArmoniK CLI is a tool to monitor and manage ArmoniK clusters.

--- a/src/armonik_cli/commands/partitions.py
+++ b/src/armonik_cli/commands/partitions.py
@@ -7,13 +7,14 @@ from armonik.client.partitions import ArmoniKPartitions
 from armonik.common.filter import Filter, PartitionFilter
 from armonik.common import Partition, Direction
 
-from armonik_cli.core import console, base_command
+from armonik_cli.core import console, base_command, base_group
 from armonik_cli.core.params import FilterParam, FieldParam
 
 PARTITIONS_TABLE_COLS = [("ID", "Id"), ("PodReserved", "PodReserved"), ("PodMax", "PodMax")]
 
 
 @click.group(name="partition")
+@base_group
 def partitions() -> None:
     """Manage cluster partitions."""
     pass

--- a/src/armonik_cli/commands/sessions.py
+++ b/src/armonik_cli/commands/sessions.py
@@ -8,7 +8,14 @@ from armonik.client.sessions import ArmoniKSessions
 from armonik.common import SessionStatus, Session, TaskOptions, Direction
 from armonik.common.filter import SessionFilter, Filter
 
-from armonik_cli.core import console, base_command, KeyValuePairParam, TimeDeltaParam, FilterParam
+from armonik_cli.core import (
+    console,
+    base_command,
+    KeyValuePairParam,
+    TimeDeltaParam,
+    FilterParam,
+    base_group,
+)
 from armonik_cli.core.params import FieldParam
 
 
@@ -17,6 +24,7 @@ session_argument = click.argument("session-id", required=True, type=str, metavar
 
 
 @click.group(name="session")
+@base_group
 def sessions() -> None:
     """Manage cluster sessions."""
     pass

--- a/src/armonik_cli/commands/tasks.py
+++ b/src/armonik_cli/commands/tasks.py
@@ -8,7 +8,7 @@ from armonik.client.tasks import ArmoniKTasks
 from armonik.common import Task, TaskStatus, TaskDefinition, TaskOptions, Direction
 from armonik.common.filter import TaskFilter, Filter
 
-from armonik_cli.core import console, base_command
+from armonik_cli.core import console, base_command, base_group
 from armonik_cli.core.params import KeyValuePairParam, TimeDeltaParam, FilterParam, FieldParam
 from armonik_cli.exceptions import InternalError
 
@@ -16,6 +16,7 @@ TASKS_TABLE_COLS = [("ID", "Id"), ("Status", "Status"), ("CreatedAt", "CreatedAt
 
 
 @click.group(name="task")
+@base_group
 def tasks() -> None:
     """Manage cluster's tasks."""
     pass

--- a/src/armonik_cli/core/__init__.py
+++ b/src/armonik_cli/core/__init__.py
@@ -1,6 +1,13 @@
 from armonik_cli.core.console import console
-from armonik_cli.core.decorators import base_command
+from armonik_cli.core.decorators import base_command, base_group
 from armonik_cli.core.params import KeyValuePairParam, TimeDeltaParam, FilterParam
 
 
-__all__ = ["base_command", "KeyValuePairParam", "TimeDeltaParam", "FilterParam", "console"]
+__all__ = [
+    "base_command",
+    "KeyValuePairParam",
+    "TimeDeltaParam",
+    "FilterParam",
+    "console",
+    "base_group",
+]

--- a/src/armonik_cli/core/common.py
+++ b/src/armonik_cli/core/common.py
@@ -1,0 +1,85 @@
+import rich_click as click
+
+from typing import Callable, Any
+from typing_extensions import TypeAlias
+
+from armonik_cli.core.options import GlobalOption
+
+
+ClickOption: TypeAlias = Callable[[Callable[..., Any]], Callable[..., Any]]
+
+
+endpoint_option = click.option(
+    "-e",
+    "--endpoint",
+    type=str,
+    required=True,
+    help="Endpoint of the cluster to connect to.",
+    metavar="ENDPOINT",
+    cls=GlobalOption,
+)
+
+
+output_option = click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["yaml", "json", "table"], case_sensitive=False),
+    default="json",
+    show_default=True,
+    help="Commands output format.",
+    metavar="FORMAT",
+    cls=GlobalOption,
+)
+
+
+debug_option = click.option(
+    "--debug",
+    is_flag=True,
+    default=False,
+    help="Print debug logs and internal errors.",
+    cls=GlobalOption,
+)
+
+
+def apply_click_params(
+    command: Callable[..., Any], *click_options: ClickOption
+) -> Callable[..., Any]:
+    """
+    Applies multiple Click options to a command.
+
+    Args:
+        command: The Click command function to decorate.
+        *click_options: The Click options to apply.
+
+    Returns:
+        The decorated command function.
+    """
+    for click_option in click_options:
+        command = click_option(command)
+    return command
+
+
+def global_cluster_config_options(command: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    Adds global cluster configuration options to a Click command.
+
+    Args:
+        command: The Click command function to decorate.
+
+    Returns:
+        The decorated command function.
+    """
+    return apply_click_params(command, endpoint_option)
+
+
+def global_common_options(command: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    Adds global common options such as output format and debug mode to a Click command.
+
+    Args:
+        command: The Click command function to decorate.
+
+    Returns:
+        The decorated command function.
+    """
+    return apply_click_params(command, output_option, debug_option)

--- a/src/armonik_cli/core/options.py
+++ b/src/armonik_cli/core/options.py
@@ -1,0 +1,45 @@
+import rich_click as click
+
+from typing import Any
+
+
+class GlobalOption(click.Option):
+    """
+    A custom Click option that allows the option to be passed anywhere in the command path.
+
+    This class extends the standard Click Option to enable the option to be recognized
+    and processed regardless of its position in the command hierarchy.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.globally_required = kwargs.pop("required", False)
+        super().__init__(*args, **kwargs, required=False)
+
+    def process_value(self, ctx: click.Context, value: Any) -> Any:
+        """
+        Process the value of the option.
+
+        This method overrides the default behavior to check if the option's value
+        is not provided in the current context but is available in the parent context.
+
+        So, if all the command groups in a command path have the same option using this
+        class, then successive evaluation of the process_value method will forward the
+        value of the option wherever it is provided in the command hierarchy.
+
+        Args:
+            ctx: The current context in which the option is being processed.
+            value: The value of the option provided in the current context.
+
+        Returns:
+            The processed value of the option.
+        """
+        value = super().process_value(ctx, value)
+        # If the option is not passed at this level of the command hierarchy, try to retrieve it from
+        # the parent command, if one exists.
+        if (not value or value == self.default) and ctx.parent and self.name in ctx.parent.params:
+            value = ctx.parent.params[self.name]
+        # Raise an exception if the option is required and has not been passed at any level of the
+        # command hierarchy.
+        if not value and not isinstance(ctx.command, click.Group) and self.globally_required:
+            raise click.MissingParameter(ctx=ctx)
+        return value

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -2,7 +2,7 @@ import pytest
 
 from grpc import RpcError, StatusCode
 
-from armonik_cli.core.decorators import error_handler, base_command
+from armonik_cli.core.decorators import error_handler, base_command, base_group
 from armonik_cli.exceptions import NotFoundError, InternalError
 
 
@@ -50,6 +50,19 @@ def test_error_handler_other_debug(decorator):
     raise_error(debug=True)
 
 
+@pytest.mark.parametrize("decorator", [base_group, base_group()])
+def test_base_group(decorator):
+    @decorator
+    def test_func():
+        pass
+
+    assert test_func.__name__ == "test_func"
+    assert len(test_func.__click_params__) == 3
+    assert test_func.__click_params__[0].name == "output"
+    assert test_func.__click_params__[1].name == "debug"
+    assert test_func.__click_params__[2].name == "endpoint"
+
+
 @pytest.mark.parametrize("decorator", [base_command, base_command()])
 def test_base_command(decorator):
     @decorator
@@ -58,6 +71,6 @@ def test_base_command(decorator):
 
     assert test_func.__name__ == "test_func"
     assert len(test_func.__click_params__) == 3
-    assert test_func.__click_params__[0].name == "debug"
-    assert test_func.__click_params__[1].name == "output"
+    assert test_func.__click_params__[0].name == "output"
+    assert test_func.__click_params__[1].name == "debug"
     assert test_func.__click_params__[2].name == "endpoint"

--- a/tests/core/test_options.py
+++ b/tests/core/test_options.py
@@ -1,0 +1,64 @@
+import pytest
+import rich_click as click
+
+from click.testing import CliRunner
+
+from armonik_cli.core.options import GlobalOption
+
+
+@pytest.fixture(scope="module")
+def cli_global_option():
+    global_option_1 = click.option("--foo", type=str, cls=GlobalOption, default="value0")
+    global_option_2 = click.option("--bar", type=str, cls=GlobalOption, required=True)
+
+    @click.group()
+    @global_option_1
+    @global_option_2
+    def cli(foo, bar):
+        pass
+
+    @cli.command()
+    @global_option_1
+    @global_option_2
+    def command(foo, bar):
+        click.echo(f"foo={foo}, bar={bar}")
+
+    return cli
+
+
+def test_global_option_at_group_level(cli_global_option):
+    runner = CliRunner()
+    result = runner.invoke(cli_global_option, ["--foo", "value1", "--bar", "value2", "command"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "foo=value1, bar=value2"
+
+
+def test_global_option_at_command_level(cli_global_option):
+    runner = CliRunner()
+    result = runner.invoke(cli_global_option, ["command", "--foo", "value1", "--bar", "value2"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "foo=value1, bar=value2"
+
+
+def test_global_option_at_group_and_command_level(cli_global_option):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_global_option,
+        ["--foo", "value1", "--bar", "value2", "command", "--foo", "value3", "--bar", "value4"],
+    )
+    assert result.exit_code == 0
+    assert result.output.strip() == "foo=value3, bar=value4"
+
+
+def test_global_option_default_value(cli_global_option):
+    runner = CliRunner()
+    result = runner.invoke(cli_global_option, ["--bar", "value2", "command"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "foo=value0, bar=value2"
+
+
+def test_global_option_required_missing(cli_global_option):
+    runner = CliRunner()
+    result = runner.invoke(cli_global_option, ["command"])
+    assert result.exit_code == 2
+    assert "Missing option" in result.output


### PR DESCRIPTION
# Motivation

In the current version of the CLI, all commands share common options, namely : --endpoint, --output and --debug. These options can only be passed after the last command. It would be preferable to be able to pass them at any level of the command hierarchy, to simplify the entry of new commands with identical values for some or all of these options.

For example, the three following commands should be allowed and work identically.
`armonik --endpoint <endpoint> session list`
`armonik session --endpoint <endpoint> list`
`armonik session list --endpoint <endpoint>`

# Description

Implements a custom option type called GlobalOption supporting value passing at any level of the command hierarchy, as well as a base_group decorator to add common options to all command groups easily.


# Testing

Manually tested and unit tests are added.

# Impact

No impact.

# Additional Information

No.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
