### PR TITLE
fix: task create now returns a single task object

### DIFF
--- a/src/armonik_cli/commands/tasks.py
+++ b/src/armonik_cli/commands/tasks.py
@@ -247,7 +247,7 @@ def tasks_create(
         submitted_tasks = tasks_client.submit_tasks(session_id, [task_definition])
 
         console.formatted_print(
-            [_clean_up_status(t) for t in submitted_tasks],
+            _clean_up_status(submitted_tasks[0]),
             format=output,
             table_cols=TASKS_TABLE_COLS,
         )

--- a/tests/commands/test_tasks.py
+++ b/tests/commands/test_tasks.py
@@ -279,6 +279,4 @@ def test_task_cancel(mocker, cmd):
 )
 def test_task_create(mocker, cmd, exit_code):
     mocker.patch.object(ArmoniKTasks, "submit_tasks", return_value=[deepcopy(raw_tasks[0])])
-    result = run_cmd_and_assert_exit_code(cmd)
-    if exit_code != 0:
-        assert "error" in result.output.lower()
+    run_cmd_and_assert_exit_code(cmd, exit_code=exit_code)

--- a/tests/commands/test_tasks.py
+++ b/tests/commands/test_tasks.py
@@ -278,5 +278,7 @@ def test_task_cancel(mocker, cmd):
     ],
 )
 def test_task_create(mocker, cmd, exit_code):
-    mocker.patch.object(ArmoniKTasks, "submit_tasks", return_value=[])
-    run_cmd_and_assert_exit_code(cmd, exit_code=exit_code)
+    mocker.patch.object(ArmoniKTasks, "submit_tasks", return_value=[deepcopy(raw_tasks[0])])
+    result = run_cmd_and_assert_exit_code(cmd)
+    if exit_code != 0:
+        assert "error" in result.output.lower()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import json
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from click.testing import CliRunner, Result
 
@@ -26,7 +26,7 @@ def run_cmd_and_assert_exit_code(
 
 def reformat_cmd_output(
     output: str, deserialize: bool = False, first_line_out: bool = False
-) -> str:
+) -> Union[str, Dict[str, Any]]:
     if first_line_out:
         output = "\n".join(output.split("\n")[1:])
     output = output.replace("\n", "")


### PR DESCRIPTION
# Motivation

`task create` would return a list with a single task object

# Description

- `task create` now returns a singular task object instead
- changed the return type of `reformat_cmd_output` from `str` to `Union[str, Dict[str, Any]]`

# Testing

Unit tests pass but it uses the new error handler which produces click errors (which obfuscate exit codes..) 

# Impact

Small improvements towards a better and more consistent tool. 

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
