### PR TITLE
docs: Added documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/armonik_core.rst
+++ b/docs/armonik_core.rst
@@ -1,0 +1,7 @@
+ArmoniK.CLI Core
+======================
+
+This is arguable one of the main things you'll be interacting with when working on ArmoniK.CLI.
+
+We'll give an overview of the various custom decorators, parameter types and objects that are provided. 
+*TODO*

--- a/docs/cli_reference.rst
+++ b/docs/cli_reference.rst
@@ -1,0 +1,6 @@
+CLI Reference
+=============
+
+.. click:: armonik_cli.cli:cli
+   :prog: armonik_cli
+   :show-nested:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,40 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "ArmoniK CLI"
+copyright = "2024, Aneo"
+author = "Quentin Delamea"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx_click",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "collapse_navigation": False,
+    "sticky_navigation": False,
+    "navigation_depth": 3,
+    "includehidden": True,
+    "titles_only": True,
+}
+# html_logo = "_static/logo.png"
+# html_favicon = "_static/favicon.ico"
+html_static_path = ["_static"]
+html_css_files = ["custom.css"]

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,0 +1,135 @@
+Working on ArmoniK.CLI
+============================
+
+
+Configuring ArmoniK.CLI for development
+---------------------------------------------
+
+
+Requirements
+`````````````
+
+The CLI requires Python version 3.8 or newer. In order to install the ArmoniK CLI in an isolated environment, you must have python3-venv installed on your machine.
+
+.. code-block:: console 
+
+    $ sudo apt update && sudo apt install python3-venv
+
+
+Installation
+`````````````
+
+To install the CLI from source, first clone this repository.
+
+.. code-block:: console 
+
+    $ git clone git@github.com/aneoconsulting/ArmoniK.Admin.CLI.git
+
+
+Navigate in the root directory
+
+.. code-block:: console 
+
+    $ cd ArmoniK.Admin.CLI
+
+
+Create and activate the virtual environment
+
+.. code-block:: console 
+
+    $ python -m venv ./venv
+    $ source ./venv/bin/activate
+
+
+Perform an editable install of the ArmoniK.CLI
+
+.. code-block:: console 
+
+    $ pip install -e .
+
+
+Running tests
+`````````````
+
+We use pytest for unit tests
+
+.. code-block:: console 
+
+    $ pytest tests/
+
+
+To run the integration test you can just deploy ArmoniK locally and then run
+
+.. code-block:: console
+
+    $ pytest tests/integration.py 
+
+
+
+Linting and formatting
+``````````````````````
+
+Install the development packages
+
+.. code-block:: console 
+
+    $ pip install '.[dev]'
+
+
+Formatting 
+
+.. code-block:: console 
+
+    $ ruff format
+
+
+Linting
+
+.. code-block:: console 
+
+    $ ruff check . 
+
+
+Documentation
+`````````````
+Install the documentation packages 
+
+.. code-block:: console 
+
+    $ pip install '.[docs]'
+
+Serving the documentation locally 
+
+.. code-block:: console
+
+    $ sphinx-autobuild docs docs/_build/html 
+
+Building the documentation 
+
+.. code-block:: console 
+
+    $ cd docs
+    $ make html
+
+Using ArmoniK.CLI with a custom version of ArmoniK Python API
+-------------------------------------------------------------------
+
+ArmoniK.CLI makes use of a good chunk of the ArmoniK Python API which makes it especially potent 
+when it comes to driving the development of said package. You can perform an editable install of the armonik package
+
+.. code-block:: toml 
+
+    dependencies = [
+        "armonik @ file://local_armonik_repo_folder/ArmoniK.Api/packages/python"
+    ]
+
+where you can point to your local ArmoniK package.
+
+Another option is to perform an editable install of said package in the CLI project environment.
+
+Extension support
+-----------------
+
+Another way to contribute to ArmoniK.CLI is through extensions. 
+Support for this feature is still in ongoing development but for functionality that doesn't feel core to 
+the experience of ArmoniK.CLI extensions will be the prefered way moving forward.   

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,19 @@
+ArmoniK CLI documentation
+=========================
+
+This repository is part of the `ArmoniK <https://github.com/aneoconsulting/ArmoniK>`_ project. It provides a command-line tool to monitor and manage ArmoniK clusters.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+
+   installation
+   usage
+   cli_reference
+
+.. toctree:: 
+   :maxdepth: 3
+   :caption: Developer's Guide
+
+   development
+   armonik_core

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,50 @@
+Installation
+============
+
+Requirements
+------------
+
+- Python 3.8+
+- An ArmoniK deployment to run the commands against.
+
+Install from source
+-------------------
+
+To install the CLI from source, first clone this repository.
+
+.. code-block:: console
+   
+   $ git clone git@github.com/aneoconsulting/ArmoniK.Admin.CLI.git
+
+
+Navigate in the root directory
+
+.. code-block:: console
+
+   $ cd ArmoniK.Admin.CLI
+
+
+Create and activate the virtual environment
+
+.. code-block:: console
+
+   $ python -m venv ./venv
+   $ source ./venv/bin/activate
+
+
+Install the CLI in the environment you just created.
+
+.. code-block:: console
+
+   $ pip install .
+
+
+Install from PyPI
+-----------------
+
+Install ArmoniK CLI 
+
+.. code-block:: console
+
+   $ pip install armonik-cli
+

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,66 @@
+Working with ArmoniK.CLI
+==============================
+
+the ArmoniK CLI offers commands to work with the different ArmoniK objects, for more information about how to use these specific 
+commands please refer to the :doc:`CLI Reference <./cli_reference>` or use the help command for the command groups
+of the different ArmoniK entities. `-h` is your best friend !
+
+Global Options
+--------------
+
+For instance, assuming you have ArmoniK deployed with an endpoint `170.10.10.122:5001` you can create a session 
+by running 
+
+.. code-block:: console 
+
+    $ armonik session create --max-duration 00:01:00.00 --priority 1  --max-retries 1 --endpoint 170.10.10.122:5001
+
+All ArmoniK CLI without exception take the options: `endpoint`, `debug` and `output`. As such, they've been made global options. 
+This allows you to write something like : 
+
+.. code-block:: console 
+
+    $ armonik session -e 170.10.10.122:5001 create --max-duration 00:01:00.00 --priority 1  --max-retries 1
+
+The `output` option lets you control the desired format for your output. It's `json` by default but you can also choose `table` or `yaml` 
+depending on your preference. While the `debug` flag lets you get a stacktrace of the execution on failure (it's omitted by default and replaced with a more concise error message).
+
+
+Filters
+-------
+
+All of the list commands for the various ArmoniK objects (sessions, tasks, etc.) have a common filter option that allows you to, as the name suggests, query for entities that 
+satisfy a specific condition. 
+
+For instance, say we want to get all of the tasks associated with a specific session 
+
+.. code-block:: console 
+
+    $ armonik task list -e 170.10.10.122:5001 --filter "session_id="1085c427-89da-4104-aa32-bc6d3d84d2b2'" --output table   
+
+or if we want to list all of the tasks within a specific session that have error'd out we can do 
+
+.. code-block:: console 
+
+    $ armonik task list -e 172.17.63.166:5001 --filter "session_id='1085c427-89da-4104-aa32-bc6d3d84d2b2' & status = error" --output table  
+
+Filters are a very powerful tool when put to good use. Although we don't have a full list of all of the ArmoniK entities' attributes 
+that you can filter with, you can go through the ArmoniK entities yourself and look through the attributes that are tagged
+with FilterDescriptors. Those are generally safe to use. You can also find out more about the different operations that filters support 
+by looking through the unit tests for filters. Hopefully this won't be the case when this section gets expanded in the future. 
+
+
+Pages and Sorting
+-----------------
+
+Whenever you run a list command, the CLI automatically retrieves all of the entities. You can specify a specific page, as well as a page size 
+by passing in the `--page` and `--page-size` arguments. 
+
+Another thing you can do is sort your results in either ascending or descending order. You can pick the attribute to sort with using the `--sort-by` 
+option, and the order using the `--sort-direction`. 
+
+For instance, making use of all of these options we can get the first 100 tasks to have been created.
+
+.. code-block:: console 
+
+    $ armonik task list -e 172.17.63.166:5001 --filter "session_id='1085c427-89da-4104-aa32-bc6d3d84d2b2'" --sort-by "created_at" --output table --page 1  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,12 @@ dev = [
     'ruff',
     'types-PyYAML',
 ]
+docs = [
+    "sphinx",
+    "sphinx-click",
+    "sphinx-rtd-theme",
+    "sphinx-autobuild"
+]
 
 [project.scripts]
 armonik = "armonik_cli.cli:cli"


### PR DESCRIPTION
# Motivation

Need for a documentation site to serve as the foundation. Ideally, we need to set it up at this point so it can "force" as internally  to incrementally update and build upon said documentation  with each new PR.

# Description

Built upon @qdelamea-aneo's previous configuration in `qd/docs` as well as my initial PR ( #37 ) on documentation which used MkDocs. The choice of going with Sphinx made more sense because it's also being used in other ArmoniK projects. 

Added a "Getting Started" for both users and developers as well as a general installation guide, as well as hot reloading/local serving with sphinx-autobuild. 

# Testing

Not applicable. 

# Impact

Not applicable.

# Additional Information

Pipelines to automatically build and publish the documentation aren't in place yet. Another question for the future is potentially setting up "standards" for this documentation. 

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
