### PR TITLE
fix: Filter parameter parsing error messages

### DIFF
--- a/src/armonik_cli/core/params.py
+++ b/src/armonik_cli/core/params.py
@@ -10,10 +10,10 @@ from pathlib import Path
 from armonik import common
 from armonik.common import Filter
 from armonik.common.filter.filter import FType
-from lark.exceptions import VisitError, UnexpectedInput
+from lark.exceptions import VisitError
 
 from armonik_cli.utils import parse_time_delta
-from armonik_cli.core.filters import FilterParser
+from armonik_cli.core.filters import FilterParser, ParsingError
 
 
 class KeyValuePairParam(click.ParamType):
@@ -135,8 +135,8 @@ class FilterParam(click.ParamType):
         """
         try:
             return self.parser.parse(value)
-        except UnexpectedInput as error:
-            self.fail(f"Filter syntax error: {error.get_context(value, span=40)}.", param, ctx)
+        except ParsingError as error:
+            self.fail(str(error), param, ctx)
         except VisitError as error:
             self.fail(str(error.orig_exc), param, ctx)
 


### PR DESCRIPTION
# Motivation

The error messages displayed for some invalid filter expressions are obscure. These are expressions that do not respect the grammar and therefore cause an error during parsing.

# Description

Added a new exception for parsing errors and an additional logic to intercept parsing issues and infer the reason to display a clear message.

# Testing

Unit tests still pass.

# Impact

No impact.

# Additional Information

Error messages are inferred from examples to best describe the situation causing the error. These examples should be completed over time to provide the most appropriate error messages for each situation.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
