### PR TITLE
feat: Added option groups

### DIFF
--- a/src/armonik_cli/cli.py
+++ b/src/armonik_cli/cli.py
@@ -1,5 +1,9 @@
 import rich_click as click
 
+from typing import Dict, List, Union
+
+from rich_click.utils import OptionGroupDict
+
 from armonik_cli import commands, __version__
 from armonik_cli.core import base_group
 
@@ -19,3 +23,64 @@ cli.add_command(commands.tasks)
 cli.add_command(commands.partitions)
 cli.add_command(commands.results)
 cli.add_command(commands.cluster)
+
+
+def get_command_paths_with_options(
+    command: Union[click.Group, click.Command], parent: str = ""
+) -> Dict[str, List[str]]:
+    """
+    Recursively retrieve all command paths and their associated options.
+
+    Args:
+        command: The root Click command or group.
+        parent: The command path prefix for recursion.
+
+    Returns:
+        A dictionary where keys are command paths and values are
+        strings listing their available options.
+    """
+    paths = {}
+
+    full_path = f"{parent} {command.name}".strip()
+
+    # Retrieve options as a string
+    paths[full_path] = [
+        max(opt.opts, key=len) for opt in command.params if isinstance(opt, click.Option)
+    ]
+
+    # Recurse if the command is a group
+    if isinstance(command, click.Group):
+        for subcommand in command.commands.values():
+            paths.update(get_command_paths_with_options(subcommand, full_path))
+
+    return paths
+
+
+COMMON_OPTIONS_GROUP: OptionGroupDict = {
+    "name": "Common options",
+    "options": ["--debug", "--help", "--output"],
+}
+
+CLUSTER_CONFIG_OPTIONS_GROUP: OptionGroupDict = {
+    "name": "Cluster config options",
+    "options": ["--endpoint"],
+}
+
+click.rich_click.OPTION_GROUPS = {
+    path: [
+        COMMON_OPTIONS_GROUP,
+        CLUSTER_CONFIG_OPTIONS_GROUP,
+        {
+            "name": "Command-specific options",
+            "options": sorted(
+                [
+                    opt
+                    for opt in options
+                    if opt
+                    not in COMMON_OPTIONS_GROUP["options"] + CLUSTER_CONFIG_OPTIONS_GROUP["options"]
+                ]
+            ),
+        },
+    ]
+    for path, options in get_command_paths_with_options(cli).items()
+}


### PR DESCRIPTION
# Motivation

In the command help messages, all the options are grouped together and the alphabetical order is not respected. Some options, however, are global and should be distinguished from command-specific options.

# Description

Added command groups that divide options into three groups in help messages: common options (e.g. --output, --debug, etc.), cluster configuration options (e.g. --endpoint, etc) and command-specific options. Within a group, options are listed in alphabetical order.

# Testing

No unit tests. As the result is visual, it has been manually validated.

# Impact

Not applicable.

# Additional Information

* Future global options must be added to the corresponding option group.
* If future commands have no global options (or only a subset), the behavior implemented here will have to be adapted.
* Styling effects can be added to groups, but are not included in these modifications.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
