### PR TITLE
refactor: changes so all commands use config

### DIFF
--- a/src/armonik_cli/commands/cluster.py
+++ b/src/armonik_cli/commands/cluster.py
@@ -1,4 +1,3 @@
-import grpc
 import rich_click as click
 
 from armonik.client.versions import ArmoniKVersions
@@ -9,6 +8,7 @@ from rich.text import Text
 from rich import print
 
 from armonik_cli.core import console, base_command, base_group
+from armonik_cli.core.configuration import CliConfig, create_grpc_channel
 
 
 @click.group(name="cluster")
@@ -19,19 +19,19 @@ def cluster() -> None:
 
 
 @cluster.command(name="info")
-@base_command
-def cluster_info(endpoint: str, output: str, debug: bool) -> None:
+@base_command(pass_config=True, auto_output="table")
+def cluster_info(config: CliConfig, **kwargs) -> None:
     """Get basic information on the ArmoniK cluster (endpoint, versions)"""
-    with grpc.insecure_channel(endpoint) as channel:
+    with create_grpc_channel(config) as channel:
         versions_client = ArmoniKVersions(channel)
         version_info = versions_client.list_versions()
 
-        if output == "table":
+        if config.output == "table":
             grid = Table.grid(padding=(0, 1))
             grid.add_column("Label", justify="left", style="cyan", no_wrap=True)
             grid.add_column("Value", style="green", justify="left")
 
-            grid.add_row("Endpoint:", endpoint)
+            grid.add_row("Endpoint:", config.endpoint)
             grid.add_row("Core Version:", version_info["core"])
             grid.add_row("API Version:", version_info["api"])
 
@@ -39,21 +39,21 @@ def cluster_info(endpoint: str, output: str, debug: bool) -> None:
             print(panel)
         else:
             cluster_info = {
-                "Endpoint": endpoint,
+                "Endpoint": config.endpoint,
                 "Versions": {"Core": version_info["core"], "API": version_info["api"]},
             }
-            console.formatted_print(cluster_info, print_format=output)
+            console.formatted_print(cluster_info, print_format=config.output)
 
 
 @cluster.command(name="health")
-@base_command
-def cluster_health(endpoint: str, output: str, debug: bool) -> None:
+@base_command(pass_config=True, auto_output="table")
+def cluster_health(config: CliConfig, **kwargs) -> None:
     """Get information on the health of some components of the ArmoniK cluster"""
-    with grpc.insecure_channel(endpoint) as channel:
+    with create_grpc_channel(config) as channel:
         health_client = ArmoniKHealthChecks(channel)
         health_status = health_client.check_health()
 
-        if output == "table":
+        if config.output == "table":
             grid = Table.grid(padding=(0, 1))
             grid.add_column("Service", style="cyan", justify="left")
             grid.add_column("Status", style="green", justify="left")
@@ -71,4 +71,4 @@ def cluster_health(endpoint: str, output: str, debug: bool) -> None:
             panel = Panel(grid, title="Health Status", border_style="blue")
             print(panel)
         else:
-            console.formatted_print(health_status, print_format=output)
+            console.formatted_print(health_status, print_format=config.output)

--- a/src/armonik_cli/core/common.py
+++ b/src/armonik_cli/core/common.py
@@ -2,7 +2,7 @@ import rich_click as click
 
 from typing import Callable, Any, Dict, List, Union
 from typing_extensions import TypeAlias
-from armonik_cli.core.configuration import endpoint_option, output_option, debug_option, CliConfig
+from armonik_cli.core.configuration import CliConfig
 
 from rich_click.utils import OptionGroupDict
 
@@ -26,32 +26,6 @@ def apply_click_params(
     for click_option in click_options:
         command = click_option(command)
     return command
-
-
-def global_cluster_config_options(command: Callable[..., Any]) -> Callable[..., Any]:
-    """
-    Adds global cluster configuration options to a Click command.
-
-    Args:
-        command: The Click command function to decorate.
-
-    Returns:
-        The decorated command function.
-    """
-    return apply_click_params(command, endpoint_option)
-
-
-def global_common_options(command: Callable[..., Any]) -> Callable[..., Any]:
-    """
-    Adds global common options such as output format and debug mode to a Click command.
-
-    Args:
-        command: The Click command function to decorate.
-
-    Returns:
-        The decorated command function.
-    """
-    return apply_click_params(command, output_option, debug_option)
 
 
 def get_command_paths_with_options(

--- a/src/armonik_cli/core/configuration.py
+++ b/src/armonik_cli/core/configuration.py
@@ -1,10 +1,13 @@
 import yaml
+import grpc
 
 import rich_click as click
 
 from typing import Any, Callable, Literal, Optional
 from pathlib import Path
 from armonik_cli.core.options import GlobalOption
+
+from armonik.common.channel import create_channel
 
 from click import get_app_dir
 from pydantic import BaseModel, Field
@@ -46,41 +49,6 @@ def CliField(
     return field_info
 
 
-endpoint_option = click.option(
-    "-e",
-    "--endpoint",
-    type=str,
-    help="Endpoint of the cluster to connect to.",
-    metavar="ENDPOINT",
-    envvar="AK_ENDPOINT",
-    cls=GlobalOption,
-)
-
-
-output_option = click.option(
-    "-o",
-    "--output",
-    type=click.Choice(["yaml", "json", "table", "auto"], case_sensitive=False),
-    default="auto",
-    show_default=True,
-    help="Commands output format.",
-    metavar="FORMAT",
-    envvar="AK_OUTPUT",
-    cls=GlobalOption,
-)
-
-
-debug_option = click.option(
-    "--debug/--no-debug",
-    is_flag=True,
-    default=False,
-    help="Print debug logs and internal errors.",
-    show_default=True,
-    envvar="AK_DEBUG",
-    cls=GlobalOption,
-)
-
-
 class CliConfig:
     default_path = Path(get_app_dir("armonik_cli")) / "config.yml"
 
@@ -88,19 +56,88 @@ class CliConfig:
         endpoint: Optional[str] = CliField(
             description="ArmoniK gRPC endpoint to connect to.",
             cli_option_group="ClusterConnection",
-            cli_option=endpoint_option,
+            cli_option=click.option(
+                "-e",
+                "--endpoint",
+                type=str,
+                help="Endpoint of the cluster to connect to.",
+                metavar="ENDPOINT",
+                envvar="AK_ENDPOINT",
+                cls=GlobalOption,
+            ),
         )
+
+        certificate_authority: Optional[Path] = CliField(
+            description="Path to the certificate authority file.",
+            cli_option_group="ClusterConnection",
+            default=None,
+            cli_option=click.option(
+                "--certificate-authority",
+                type=click.Path(exists=True, dir_okay=False),
+                help="Path to the certificate authority file.",
+                required=False,
+                metavar="CA_FILE",
+                cls=GlobalOption,
+            ),
+        )
+
+        client_certificate: Optional[Path] = CliField(
+            description="Path to the client certificate file.",
+            cli_option_group="ClusterConnection",
+            default=None,
+            cli_option=click.option(
+                "--client-certificate",
+                type=click.Path(exists=True, dir_okay=False),
+                help="Path to the client certificate file.",
+                required=False,
+                metavar="CERT_FILE",
+                cls=GlobalOption,
+            ),
+        )
+
+        client_key: Optional[Path] = CliField(
+            description="Path to the client key file.",
+            cli_option_group="ClusterConnection",
+            default=None,
+            cli_option=click.option(
+                "--client-key",
+                type=click.Path(exists=True, dir_okay=False),
+                required=False,
+                help="Path to the client key file.",
+                metavar="KEY_FILE",
+                cls=GlobalOption,
+            ),
+        )
+
         debug: bool = CliField(
             default=False,
             description="Whether to print the stack trace of internal errors.",
             cli_option_group="Common",
-            cli_option=debug_option,
+            cli_option=click.option(
+                "--debug/--no-debug",
+                is_flag=True,
+                default=False,
+                help="Print debug logs and internal errors.",
+                show_default=True,
+                envvar="AK_DEBUG",
+                cls=GlobalOption,
+            ),
         )
         output: Literal["json", "yaml", "table", "auto"] = CliField(
             default="auto",
             description="Commands output format.",
             cli_option_group="Common",
-            cli_option=output_option,
+            cli_option=click.option(
+                "-o",
+                "--output",
+                type=click.Choice(["yaml", "json", "table", "auto"], case_sensitive=False),
+                default="auto",
+                show_default=True,
+                help="Commands output format.",
+                metavar="FORMAT",
+                envvar="AK_OUTPUT",
+                cls=GlobalOption,
+            ),
         )
 
     @classmethod
@@ -242,3 +279,21 @@ class CliConfig:
         """
         validated_model = self.ConfigModel.model_validate(self._config.__dict__)
         self._config = validated_model
+
+
+def create_grpc_channel(config: CliConfig) -> grpc.Channel:
+    """
+    Create a gRPC channel based on the configuration.
+    """
+    if config.certificate_authority and config.client_certificate and config.client_key:
+        # Create grpc channel with tls
+        channel = create_channel(
+            config.endpoint,
+            certificate_authority=config.certificate_authority,
+            client_certificate=config.client_certificate,
+            client_key=config.client_key,
+        )
+    else:
+        # Create insecure grpc channel
+        channel = grpc.insecure_channel(config.endpoint)
+    return channel

--- a/src/armonik_cli/core/decorators.py
+++ b/src/armonik_cli/core/decorators.py
@@ -203,6 +203,7 @@ def base_command(
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         if auto_output is not None and kwargs.get("output") == "auto":
+            kwargs["config"].output = auto_output
             kwargs["output"] = auto_output
         if not pass_config:
             kwargs.pop("config", None)

--- a/tests/commands/test_partitions.py
+++ b/tests/commands/test_partitions.py
@@ -52,7 +52,7 @@ serialized_partitions = [
 ]
 
 
-@pytest.mark.parametrize("cmd", [f"partition list -e {ENDPOINT} --debug"])
+@pytest.mark.parametrize("cmd", [f"partition list -e {ENDPOINT} --output json --debug"])
 def test_partition_list(mocker, cmd):
     mocker.patch.object(
         ArmoniKPartitions,
@@ -67,11 +67,11 @@ def test_partition_list(mocker, cmd):
     "cmd, expected_output",
     [
         (
-            f"partition get --endpoint {ENDPOINT} {serialized_partitions[0]['Id']}",
+            f"partition get --endpoint {ENDPOINT} --output json {serialized_partitions[0]['Id']}",
             [serialized_partitions[0]],
         ),
         (
-            f"partition get --endpoint {ENDPOINT} {serialized_partitions[0]['Id']} {serialized_partitions[1]['Id']}",
+            f"partition get --endpoint {ENDPOINT} --output json {serialized_partitions[0]['Id']} {serialized_partitions[1]['Id']}",
             [serialized_partitions[0], serialized_partitions[1]],
         ),
     ],

--- a/tests/commands/test_results.py
+++ b/tests/commands/test_results.py
@@ -62,7 +62,7 @@ serialized_results = [
 ]
 
 
-@pytest.mark.parametrize("cmd", [f"result list -e {ENDPOINT} -f session_id=id"])
+@pytest.mark.parametrize("cmd", [f"result list -e {ENDPOINT} --output json -f session_id=id"])
 def test_result_list(mocker, cmd):
     mocker.patch.object(ArmoniKResults, "list_results", return_value=(2, deepcopy(raw_results)))
     result = run_cmd_and_assert_exit_code(cmd)
@@ -73,11 +73,11 @@ def test_result_list(mocker, cmd):
     "cmd, expected_output",
     [
         (
-            f"result get --endpoint {ENDPOINT} {serialized_results[0]['ResultId']}",
+            f"result get --endpoint {ENDPOINT} --output json {serialized_results[0]['ResultId']}",
             [serialized_results[0]],
         ),
         (
-            f"result get --endpoint {ENDPOINT} {serialized_results[0]['ResultId']} {serialized_results[1]['ResultId']}",
+            f"result get --endpoint {ENDPOINT} --output json {serialized_results[0]['ResultId']} {serialized_results[1]['ResultId']}",
             [serialized_results[0], serialized_results[1]],
         ),
     ],

--- a/tests/commands/test_sessions.py
+++ b/tests/commands/test_sessions.py
@@ -69,7 +69,7 @@ def test_session(flag):
 @pytest.mark.parametrize(
     "cmd",
     [
-        f"session list --endpoint {ENDPOINT}",
+        f"session list --endpoint {ENDPOINT} --output json",
     ],
 )
 def test_session_list(mocker, cmd):
@@ -81,7 +81,7 @@ def test_session_list(mocker, cmd):
 @pytest.mark.parametrize(
     "cmd",
     [
-        f"session get --endpoint {ENDPOINT} id",
+        f"session get --endpoint {ENDPOINT} id --output json",
     ],
 )
 def test_session_get(mocker, cmd):
@@ -93,8 +93,8 @@ def test_session_get(mocker, cmd):
 @pytest.mark.parametrize(
     "cmd",
     [
-        f"session create --priority 1 --max-duration 01:00:0 --max-retries 2 --endpoint {ENDPOINT}",
-        f"session create --priority 1 --max-duration 01:00:0 --max-retries 2 --endpoint {ENDPOINT} "
+        f"session create --priority 1 --max-duration 01:00:0 --max-retries 2 --endpoint {ENDPOINT} --output json",
+        f"session create --priority 1 --max-duration 01:00:0 --max-retries 2 --endpoint {ENDPOINT} --output json "
         "--default-partition bench --partition bench --partition htcmock --option op1=val1 --option opt2=val2 "
         "--application-name app --application-version v1 --application-namespace ns --application-service svc --engine-type eng",
     ],

--- a/tests/commands/test_tasks.py
+++ b/tests/commands/test_tasks.py
@@ -207,7 +207,7 @@ serialized_tasks = [
 ]
 
 
-@pytest.mark.parametrize("cmd", [f"task list -e {ENDPOINT} --debug"])
+@pytest.mark.parametrize("cmd", [f"task list -e {ENDPOINT} --output json --debug"])
 def test_task_list(mocker, cmd):
     mocker.patch.object(ArmoniKTasks, "list_tasks", return_value=(2, deepcopy(raw_tasks)))
     result = run_cmd_and_assert_exit_code(cmd)
@@ -217,9 +217,12 @@ def test_task_list(mocker, cmd):
 @pytest.mark.parametrize(
     "cmd, expected_outputs",
     [
-        (f"task get --endpoint {ENDPOINT} {serialized_tasks[0]['Id']}", [serialized_tasks[0]]),
         (
-            f"task get --endpoint {ENDPOINT} {serialized_tasks[0]['Id']} {serialized_tasks[1]['Id']} --debug",
+            f"task get --endpoint {ENDPOINT} --output json {serialized_tasks[0]['Id']}",
+            [serialized_tasks[0]],
+        ),
+        (
+            f"task get --endpoint {ENDPOINT} --output json {serialized_tasks[0]['Id']} {serialized_tasks[1]['Id']} --debug",
             serialized_tasks,
         ),
     ],


### PR DESCRIPTION
# Motivation

Added CLI configuration in the previous PR but the commands still rely on getting everything from the CLI parameters

# Description

Made small changes to all the commands so they use the CliConfig instead

# Testing

Some changes had to be made to some unit tests, but they're all passing.

# Impact

Not applicable.

# Additional Information

Documentation needs to be modified for the PR to be merged, specifically going over how configs work.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
