### PR TITLE
feat: Added logging

### DIFF
--- a/src/armonik_cli/cli.py
+++ b/src/armonik_cli/cli.py
@@ -11,7 +11,7 @@ from armonik_cli.core.common import populate_option_groups
 )
 @click.version_option(version=__version__, prog_name="armonik")
 @base_group
-def cli() -> None:
+def cli(**kwargs) -> None:
     """
     ArmoniK CLI is a tool to monitor and manage ArmoniK clusters.
     """

--- a/src/armonik_cli/commands/cluster.py
+++ b/src/armonik_cli/commands/cluster.py
@@ -13,7 +13,7 @@ from armonik_cli.core.configuration import CliConfig, create_grpc_channel
 
 @click.group(name="cluster")
 @base_group
-def cluster() -> None:
+def cluster(**kwargs) -> None:
     """Manage ArmoniK cluster."""
     pass
 

--- a/src/armonik_cli/commands/config.py
+++ b/src/armonik_cli/commands/config.py
@@ -11,7 +11,7 @@ from armonik_cli.utils import pretty_type
 
 @click.group(name="config")
 @base_group
-def config() -> None:
+def config(**kwargs) -> None:
     """Manage CLI configuration."""
     pass
 

--- a/src/armonik_cli/commands/partitions.py
+++ b/src/armonik_cli/commands/partitions.py
@@ -13,7 +13,7 @@ from armonik_cli.core.configuration import CliConfig, create_grpc_channel
 
 @click.group(name="partition")
 @base_group
-def partitions() -> None:
+def partitions(**kwargs) -> None:
     """Manage cluster partitions."""
     pass
 

--- a/src/armonik_cli/commands/results.py
+++ b/src/armonik_cli/commands/results.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import logging
 import pathlib
 import grpc
 import rich_click as click
@@ -17,7 +18,7 @@ from armonik_cli.core.params import FieldParam, FilterParam, ResultNameDataParam
 
 @click.group(name="result")
 @base_group
-def results() -> None:
+def results(**kwargs) -> None:
     """Manage results."""
     pass
 
@@ -279,6 +280,7 @@ def result_upload_data(
 @base_command(pass_config=True, auto_output="json")
 def result_delete_data(
     config: CliConfig,
+    logger: logging.Logger,
     result_ids: List[str],
     confirm: bool,
     skip_not_found: bool,
@@ -293,7 +295,7 @@ def result_delete_data(
                 result = results_client.get_result(result_id)
             except grpc.RpcError as e:
                 if skip_not_found and e.code() == grpc.StatusCode.NOT_FOUND:
-                    console.print(f"Couldn't find result with id={result_id}, skipping...")
+                    logger.warning("Couldn't find result with id=%s, skipping...", result_id)
                     continue
                 else:
                     raise e

--- a/src/armonik_cli/commands/tasks.py
+++ b/src/armonik_cli/commands/tasks.py
@@ -14,7 +14,7 @@ from armonik_cli.core.params import KeyValuePairParam, TimeDeltaParam, FilterPar
 
 @click.group(name="task")
 @base_group
-def tasks() -> None:
+def tasks(**kwargs) -> None:
     """Manage cluster's tasks."""
     pass
 

--- a/src/armonik_cli/core/configuration.py
+++ b/src/armonik_cli/core/configuration.py
@@ -132,6 +132,22 @@ class CliConfig:
                 cls=GlobalOption,
             ),
         )
+
+        verbose: bool = CliField(
+            default=False,
+            description="Whether or not to log info.",
+            cli_option_group="Common",
+            cli_option=click.option(
+                "--verbose/--no-verbose",
+                is_flag=True,
+                default=False,
+                help="Whether or not to log info.",
+                show_default=True,
+                envvar="AK_VERBOSE",
+                cls=GlobalOption,
+            ),
+        )
+
         output: Literal["json", "yaml", "table", "auto"] = CliField(
             default="auto",
             description="Commands output format.",

--- a/src/armonik_cli/core/logging.py
+++ b/src/armonik_cli/core/logging.py
@@ -1,0 +1,42 @@
+import logging
+from click import get_app_dir
+from rich.logging import RichHandler
+from rich.console import Console
+from pathlib import Path
+
+
+def get_logger(name: str, debug: bool = False, verbose: bool = False) -> logging.Logger:
+    """
+    A logger for ArmoniK CLI that logs to both console and file.
+
+    - Logs warnings and above to stderr by default
+    - When verbose=True, logs info and above to stdout
+    - Always logs everything to a file in the app directory
+    """
+    log_file_path = Path(get_app_dir("armonik_cli")) / f"{name}.log"
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    verbose = verbose
+
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
+
+    # TODO: Colors (Colorama ?)
+    console_formatter = logging.Formatter("%(message)s")
+    file_formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    console_handler = RichHandler(console=Console(stderr=not verbose))
+    console_handler.setFormatter(console_formatter)
+    if debug:
+        console_handler.setLevel(logging.DEBUG)
+    elif verbose:
+        console_handler.setLevel(logging.INFO)
+    else:
+        console_handler.setLevel(logging.WARNING)
+    logger.addHandler(console_handler)
+
+    file_handler = logging.FileHandler(log_file_path)
+    file_handler.setFormatter(file_formatter)
+    file_handler.setLevel(logging.DEBUG)
+    logger.addHandler(file_handler)
+
+    return logger

--- a/tests/commands/test_partitions.py
+++ b/tests/commands/test_partitions.py
@@ -52,7 +52,7 @@ serialized_partitions = [
 ]
 
 
-@pytest.mark.parametrize("cmd", [f"partition list -e {ENDPOINT} --output json --debug"])
+@pytest.mark.parametrize("cmd", [f"partition list -e {ENDPOINT} --output json"])
 def test_partition_list(mocker, cmd):
     mocker.patch.object(
         ArmoniKPartitions,

--- a/tests/commands/test_results.py
+++ b/tests/commands/test_results.py
@@ -390,4 +390,4 @@ def test_result_download_data(mocker):
     run_cmd_and_assert_exit_code(cmd, split=False)
 
     ArmoniKResults.download_result_data.assert_called_once_with("result-id", "session-id")
-    open.assert_called_once_with(pathlib.PosixPath("output/result-id_session-id.txt"), "wb")
+    open.assert_called_with(pathlib.PosixPath("output/result-id_session-id.txt"), "wb")

--- a/tests/commands/test_tasks.py
+++ b/tests/commands/test_tasks.py
@@ -207,7 +207,7 @@ serialized_tasks = [
 ]
 
 
-@pytest.mark.parametrize("cmd", [f"task list -e {ENDPOINT} --output json --debug"])
+@pytest.mark.parametrize("cmd", [f"task list -e {ENDPOINT} --output json"])
 def test_task_list(mocker, cmd):
     mocker.patch.object(ArmoniKTasks, "list_tasks", return_value=(2, deepcopy(raw_tasks)))
     result = run_cmd_and_assert_exit_code(cmd)
@@ -222,7 +222,7 @@ def test_task_list(mocker, cmd):
             [serialized_tasks[0]],
         ),
         (
-            f"task get --endpoint {ENDPOINT} --output json {serialized_tasks[0]['Id']} {serialized_tasks[1]['Id']} --debug",
+            f"task get --endpoint {ENDPOINT} --output json {serialized_tasks[0]['Id']} {serialized_tasks[1]['Id']}",
             serialized_tasks,
         ),
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 import json
+import logging
 
 from typing import Any, Dict, Optional, Union
 
 from click.testing import CliRunner, Result
+import pytest
 
 from armonik_cli.cli import cli
 
@@ -39,3 +41,11 @@ def reformat_cmd_output(
     if deserialize:
         return json.loads(output)
     return output
+
+
+@pytest.fixture(autouse=True)
+def disable_logging():
+    """Disable all logging for tests."""
+    logging.disable(logging.CRITICAL)  # This disables all logs below CRITICAL level
+    yield
+    logging.disable(logging.NOTSET)  # Re-enable logging after the test


### PR DESCRIPTION
# Motivation

Need for a way to collect, store and properly display ArmoniK CLI logs without using print/echo.

# Description

- Added a class for logging into the terminal or file.
- Changed some prints over to logging
- Fixed a bug where group level commands get treated as defaults ([click issue](https://github.com/pallets/click/issues/2753))

# Testing

Nothing significant that needs to be tested. It's basically a simple wrapper around a basic Python object. Moreover,
the stderr output direction clearly works because previous tests are passing (Warnings go to stderr by default).

# Impact

Not applicable.

# Additional Information

Not applicable.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
