### PR TITLE
fix: Missing environment variable config and TLS fix

### DIFF
--- a/src/armonik_cli/core/configuration.py
+++ b/src/armonik_cli/core/configuration.py
@@ -353,6 +353,7 @@ def create_grpc_channel(config: CliConfig) -> grpc.Channel:
         # Create grpc channel with tls
         channel = create_channel(
             config.endpoint,
+            options=(("grpc.ssl_target_name_override", "armonik.local"),),
             certificate_authority=config.certificate_authority,
             client_certificate=config.client_certificate,
             client_key=config.client_key,

--- a/src/armonik_cli/core/decorators.py
+++ b/src/armonik_cli/core/decorators.py
@@ -99,6 +99,7 @@ def global_config_options(command: Callable[..., Any]) -> Callable[..., Any]:
             type=click.Path(exists=True, dir_okay=False),
             required=False,
             help="Path to additional config file.",
+            envvar="AKCONFIG",
             cls=GlobalOption,
         )
     ]


### PR DESCRIPTION
# Motivation

Needed an easy way to overlay the automatically generated CLI configuration.

# Description

- Added the missing environment variable (AKCONFIG) for the additional config file
- Workaround for client-side peer name verification for TLS.
 
# Testing

All previous tests pass.

# Impact

Not applicable.

# Additional Information

Not applicable.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
