### PR TITLE
feat: Added custom command class to handle multiple missing params

### DIFF
--- a/packages/armonik_cli_core/src/armonik_cli_core/commands.py
+++ b/packages/armonik_cli_core/src/armonik_cli_core/commands.py
@@ -1,0 +1,40 @@
+import rich_click as click
+
+
+class AkCommand(click.Command):
+    def parse_args(self, ctx, args):
+        # Store the original required state of the parameters
+        original_required = {param: param.required for param in self.params}
+
+        try:
+            # Temporarily mark all parameters as not required
+            for param in self.params:
+                param.required = False
+
+            # Let the parent class parse the arguments
+            # This will populate ctx.params without raising MissingParameter errors
+            super().parse_args(ctx, args)
+
+            # Custom validation logic for multiple missing parameters
+            missing_params = []
+            for param in self.get_params(ctx):
+                # Check if the parameter was originally required and is now missing
+                if original_required.get(param) and ctx.params.get(param.name) is None:
+                    missing_params.append(param)
+
+            if missing_params:
+                # Get the error hints for all missing parameters
+                param_hints = [param.get_error_hint(ctx) for param in missing_params]
+
+                if len(missing_params) > 1:
+                    error_msg = f"Missing required options: {', '.join(param_hints)}"
+                else:
+                    error_msg = f"Missing required option: {param_hints[0]}"
+
+                # Use UsageError for better formatting of this type of error
+                raise click.UsageError(error_msg, ctx=ctx)
+
+        finally:
+            # --- IMPORTANT: Restore the original 'required' state ---
+            for param in self.params:
+                param.required = original_required.get(param, False)

--- a/packages/armonik_cli_core/src/armonik_cli_core/groups.py
+++ b/packages/armonik_cli_core/src/armonik_cli_core/groups.py
@@ -2,9 +2,10 @@ import rich_click as click
 
 from rich.traceback import Traceback
 from .console import console
+from .commands import AkCommand
 
 from importlib.metadata import entry_points
-
+from functools import partial
 
 ENTRY_POINT_GROUP = "armonik.cli.extensions"
 
@@ -226,6 +227,18 @@ class ExtendableGroup(click.RichGroup):
             from armonik_cli_core.utils import populate_option_groups_incremental
 
             populate_option_groups_incremental(command, parent_path)
+
+
+class AkGroup(click.RichGroup):
+    """A custom group that forces all its commands to use AkCommand."""
+
+    def command(self, *args, **kwargs):
+        # Set the default command class for all commands in this group
+        kwargs.setdefault("cls", AkCommand)
+        return super().command(*args, **kwargs)
+
+
+ak_group = partial(click.group, cls=AkGroup)
 
 
 def setup_command_groups():

--- a/src/armonik_cli/commands/cluster.py
+++ b/src/armonik_cli/commands/cluster.py
@@ -1,4 +1,3 @@
-import rich_click as click
 
 from armonik.client.versions import ArmoniKVersions
 from armonik.client.health_checks import ArmoniKHealthChecks
@@ -9,9 +8,10 @@ from rich import print
 
 from armonik_cli_core import console, base_command, base_group
 from armonik_cli_core import CliConfig, create_grpc_channel
+from armonik_cli_core.groups import ak_group
 
 
-@click.group(name="cluster")
+@ak_group(name="cluster")
 @base_group
 def cluster(**kwargs) -> None:
     """Manage ArmoniK cluster."""

--- a/src/armonik_cli/commands/config.py
+++ b/src/armonik_cli/commands/config.py
@@ -10,12 +10,13 @@ from armonik_cli_core.configuration import CliConfig
 from armonik_cli_core import base_group, console
 from armonik_cli_core.decorators import base_command
 from armonik_cli.utils import pretty_type
+from armonik_cli_core.groups import ak_group
 
 click.rich_click.USE_RICH_MARKUP = True
 click.rich_click.USE_MARKDOWN = True
 
 
-@click.group(name="config")
+@ak_group(name="config")
 @base_group
 def config(**kwargs) -> None:
     """Manage CLI configuration."""

--- a/src/armonik_cli/commands/extensions.py
+++ b/src/armonik_cli/commands/extensions.py
@@ -4,9 +4,10 @@ from rich.table import Table
 from importlib.metadata import entry_points
 from armonik_cli_core.groups import ENTRY_POINT_GROUP
 from armonik_cli_core.console import console
+from armonik_cli_core.groups import ak_group
 
 
-@click.group(name="extension")
+@ak_group(name="extension")
 def extensions():
     """Discover and manage installed CLI extensions."""
     pass

--- a/src/armonik_cli/commands/partitions.py
+++ b/src/armonik_cli/commands/partitions.py
@@ -9,9 +9,10 @@ from armonik.common import Partition, Direction
 from armonik_cli_core import base_command, base_group
 from armonik_cli_core.params import FilterParam, FieldParam
 from armonik_cli_core.configuration import CliConfig, create_grpc_channel
+from armonik_cli_core.groups import ak_group
 
 
-@click.group(name="partition")
+@ak_group(name="partition")
 @base_group
 def partitions(**kwargs) -> None:
     """Manage cluster partitions."""

--- a/src/armonik_cli/commands/results.py
+++ b/src/armonik_cli/commands/results.py
@@ -14,9 +14,10 @@ from armonik_cli_core import console, base_command, base_group
 from armonik_cli_core.configuration import CliConfig, create_grpc_channel
 from armonik_cli_core.options import MutuallyExclusiveOption
 from armonik_cli_core.params import FieldParam, FilterParam, ResultNameDataParam
+from armonik_cli_core.groups import ak_group
 
 
-@click.group(name="result")
+@ak_group(name="result")
 @base_group
 def results(**kwargs) -> None:
     """Manage results."""

--- a/src/armonik_cli/commands/sessions.py
+++ b/src/armonik_cli/commands/sessions.py
@@ -18,9 +18,10 @@ from armonik_cli_core import (
 )
 from armonik_cli_core.configuration import CliConfig, create_grpc_channel
 from armonik_cli_core.params import FieldParam
+from armonik_cli_core.groups import ak_group
 
 
-@click.group(name="session")
+@ak_group(name="session")
 @base_group
 def sessions(**kwargs) -> None:
     """Manage cluster sessions."""

--- a/src/armonik_cli/commands/tasks.py
+++ b/src/armonik_cli/commands/tasks.py
@@ -10,9 +10,10 @@ from armonik.common.filter import TaskFilter, Filter
 from armonik_cli_core import console, base_command, base_group
 from armonik_cli_core.configuration import CliConfig, create_grpc_channel
 from armonik_cli_core.params import KeyValuePairParam, TimeDeltaParam, FilterParam, FieldParam
+from armonik_cli_core.groups import ak_group
 
 
-@click.group(name="task")
+@ak_group(name="task")
 @base_group
 def tasks(**kwargs) -> None:
     """Manage cluster's tasks."""


### PR DESCRIPTION
# Motivation

This closes #83 

When parameters are missing, Click typically fails on the very first missing parameter. We address this default behavior to improve the user experience.

# Description

This PR adds a new base command class to armonik-cli-core with some adjustments to the parameter parser; This also introduces a new Click.Group type that automatically applies this base command class to its commands. As well as a new macro `@ak_group` that defaults to this group type.

![image](https://github.com/user-attachments/assets/0af2ecdb-88db-4798-b74e-2285d3c8e92e)

# Testing

All previous tests pass.

# Impact

Not applicable.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
