### PR TITLE
feat: enable server name overriding and certificate validation bypass for TLS authentification.

### DIFF
--- a/packages/armonik_cli_core/src/armonik_cli_core/configuration.py
+++ b/packages/armonik_cli_core/src/armonik_cli_core/configuration.py
@@ -118,6 +118,36 @@ class CliConfig:
             ),
         )
 
+        server_name_override: Optional[bool] = CliField(
+            description="Override the server name used for TLS certificate verification with 'endpoint'."
+            "Useful when the server's certificate name does not match the actual endpoint.",
+            cli_option_group="ClusterConnection",
+            default=None,
+            cli_option=click.option(
+                "--server-name-override/--no-server-name-override",
+                is_flag=True,
+                default=False,
+                show_default=True,
+                help="Override the server name used for TLS certificate verification with 'endpoint'."
+                "Useful when the server's certificate name does not match the actual endpoint.",
+                cls=GlobalOption,
+            ),
+        )
+
+        bypass_validation: Optional[bool] = CliField(
+            description="Bypass certificate validation.",
+            cli_option_group="ClusterConnection",
+            default=None,
+            cli_option=click.option(
+                "--bypass-validation/--no-bypass-validation",
+                is_flag=True,
+                default=False,
+                show_default=True,
+                help="Bypass certificate validation (not recommended for production).",
+                cls=GlobalOption,
+            ),
+        )
+
         debug: bool = CliField(
             default=False,
             description="Whether to print the stack trace of internal errors.",
@@ -358,9 +388,14 @@ def create_grpc_channel(config: CliConfig) -> grpc.Channel:
         # Create grpc channel with tls
         channel = create_channel(
             cleaner_endpoint,
-            certificate_authority=config.certificate_authority,
+            certificate_authority=config.certificate_authority
+            if not config.bypass_validation
+            else None,
             client_certificate=config.client_certificate,
             client_key=config.client_key,
+            options=(("grpc.ssl_target_name_override", cleaner_endpoint),)
+            if config.server_name_override or config.bypass_validation
+            else None,
         )
     else:
         # Create insecure grpc channel


### PR DESCRIPTION
# Motivation

TLS authentication in the CLI has two limitations that complicate its use:
* It is not possible to override the server name during certificate validation.
* It is not possible to bypass CA certificate validation (very useful for local development).

# Description

This PR adds two flags to the CLI connection options to support these two behaviors.

# Testing

Tested with local deployment of ArmoniK.

# Impact

Add feature.

# Additional Information

No.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
